### PR TITLE
Add an internal representation of a running frame  Update UUID handling, deprecate proto fields, refactor frame logic

### DIFF
--- a/crates/opencue-proto/src/lib.rs
+++ b/crates/opencue-proto/src/lib.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::path::Display;
 
 use host::Host;
 use job::{Frame, Job};
@@ -31,31 +30,31 @@ pub trait WithUuid {
 
 impl WithUuid for job::Job {
     fn uuid(&self) -> Uuid {
-        to_uuid(&self.id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.id).unwrap_or(Uuid::nil())
     }
 }
 
 impl WithUuid for job::Layer {
     fn uuid(&self) -> Uuid {
-        to_uuid(&self.id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.id).unwrap_or(Uuid::nil())
     }
 }
 
 impl WithUuid for facility::Allocation {
     fn uuid(&self) -> Uuid {
-        to_uuid(&self.id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.id).unwrap_or(Uuid::nil())
     }
 }
 
 impl WithUuid for show::Show {
     fn uuid(&self) -> Uuid {
-        to_uuid(&self.id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.id).unwrap_or(Uuid::nil())
     }
 }
 
 impl WithUuid for report::RunningFrameInfo {
     fn uuid(&self) -> Uuid {
-        to_uuid(&self.frame_id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.frame_id).unwrap_or(Uuid::nil())
     }
 }
 
@@ -65,13 +64,13 @@ pub fn to_uuid(stringified_id_from_protobuf: &str) -> Option<Uuid> {
 
 impl RunFrame {
     pub fn job_id(&self) -> Uuid {
-        to_uuid(&self.job_id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.job_id).unwrap_or(Uuid::nil())
     }
     pub fn frame_id(&self) -> Uuid {
-        to_uuid(&self.frame_id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.frame_id).unwrap_or(Uuid::nil())
     }
     pub fn layer_id(&self) -> Uuid {
-        to_uuid(&self.layer_id).expect("Failed to convert Uuid, protocol version is incompatible")
+        to_uuid(&self.layer_id).unwrap_or(Uuid::nil())
     }
 }
 

--- a/crates/opencue-proto/src/lib.rs
+++ b/crates/opencue-proto/src/lib.rs
@@ -53,38 +53,25 @@ impl WithUuid for show::Show {
     }
 }
 
+impl WithUuid for report::RunningFrameInfo {
+    fn uuid(&self) -> Uuid {
+        to_uuid(&self.frame_id).expect("Failed to convert Uuid, protocol version is incompatible")
+    }
+}
+
 pub fn to_uuid(stringified_id_from_protobuf: &str) -> Option<Uuid> {
     Uuid::parse_str(stringified_id_from_protobuf).ok()
 }
 
-impl From<Frame> for RunFrame {
-    fn from(value: Frame) -> Self {
-        RunFrame {
-            resource_id: todo!(),
-            job_id: todo!(),
-            job_name: todo!(),
-            frame_id: todo!(),
-            frame_name: todo!(),
-            layer_id: todo!(),
-            command: todo!(),
-            user_name: todo!(),
-            log_dir: todo!(),
-            show: todo!(),
-            shot: todo!(),
-            job_temp_dir: todo!(),
-            frame_temp_dir: todo!(),
-            log_file: todo!(),
-            log_dir_file: todo!(),
-            start_time: todo!(),
-            num_cores: todo!(),
-            gid: todo!(),
-            ignore_nimby: todo!(),
-            environment: todo!(),
-            attributes: todo!(),
-            num_gpus: todo!(),
-            children: todo!(),
-            uid_optional: todo!(),
-        }
+impl RunFrame {
+    pub fn job_id(&self) -> Uuid {
+        to_uuid(&self.job_id).expect("Failed to convert Uuid, protocol version is incompatible")
+    }
+    pub fn frame_id(&self) -> Uuid {
+        to_uuid(&self.frame_id).expect("Failed to convert Uuid, protocol version is incompatible")
+    }
+    pub fn layer_id(&self) -> Uuid {
+        to_uuid(&self.layer_id).expect("Failed to convert Uuid, protocol version is incompatible")
     }
 }
 

--- a/crates/opencue-proto/src/protos/rqd.proto
+++ b/crates/opencue-proto/src/protos/rqd.proto
@@ -98,11 +98,18 @@ message RunFrame {
     string log_dir = 9;
     string show = 10;
     string shot = 11;
-    string job_temp_dir = 12;
+    // Deprecated: Not reliable and will not be taken on consideration moving forward
+    string job_temp_dir = 12 [deprecated=true];
     string frame_temp_dir = 13;
-    string log_file = 14;
-    string log_dir_file = 15;
-    int64 start_time = 16;
+    // Deprecated: The log_path is defined rqd using job_dir, job_name and frame_name.
+    // This field is misleading as it doesn't give cuebot the power to define the log path
+    string log_file = 14 [deprecated=true];
+    // Deprecated: The log_path is defined rqd using job_dir, job_name and frame_name.
+    // This field is misleading as it doesn't give cuebot the power to define the log path
+    string log_dir_file = 15 [deprecated=true];
+    // Deprecated: This field is never used by rqd, a frame start time is defined by rqd
+    // when the frame thread is created, therefore this field is useless and misleading.
+    int64 start_time = 16 [deprecated=true];
     oneof uid_optional {
         int32 uid = 17;
     }

--- a/crates/rqd/src/frame_thread.rs
+++ b/crates/rqd/src/frame_thread.rs
@@ -1,7 +1,0 @@
-pub struct FrameThread {}
-
-impl FrameThread {
-    pub fn run(&self) {
-        todo!()
-    }
-}

--- a/crates/rqd/src/main.rs
+++ b/crates/rqd/src/main.rs
@@ -12,7 +12,6 @@ use sysinfo::{Disks, MemoryRefreshKind, RefreshKind, System};
 use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
 
 mod config;
-mod frame_thread;
 mod monitor;
 mod report_client;
 mod running_frame;

--- a/crates/rqd/src/monitor/linux_monitor.rs
+++ b/crates/rqd/src/monitor/linux_monitor.rs
@@ -19,8 +19,11 @@ pub struct LinuxMachineStat {
     config: MachineConfig,
     sysinfo: Arc<Mutex<System>>,
     diskinfo: Arc<Mutex<Disks>>,
+    /// Map of procids indexed by physid and coreid
     procid_by_physid_and_core_id: HashMap<u32, HashMap<u32, u32>>,
+    /// The inverse map of procid_by_physid_and_core_id
     physid_and_coreid_by_procid: HashMap<u32, (u32, u32)>,
+    // Information colleced once at init time
     static_info: MachineStaticInfo,
     hardware_state: HardwareState,
     attributes: HashMap<String, String>,

--- a/crates/rqd/src/monitor/machine_monitor.rs
+++ b/crates/rqd/src/monitor/machine_monitor.rs
@@ -155,38 +155,59 @@ impl MachineMonitor {
 /// entire servive
 #[derive(Clone)]
 pub struct MachineStat {
+    /// Machine name
     pub hostname: String,
-    /// Number of proc units (also known as virtual cores)
+    /// Total number of processing units (also known as virtual cores)
     pub num_procs: u32,
+    /// Total amount of memory on the machine
     pub total_memory: u64,
+    /// Total amount of swap space on the machine
     pub total_swap: u64,
-    /// Number of sockets (also know as physical cores)
+    /// Total number of physical cores (also known as sockets)
     pub num_sockets: u32,
+    /// Number of cores per processor unit
     pub cores_per_proc: u32,
-    // Unlike the python counterpart, the multiplier is not automatically applied to total_procs
+    /// Multiplier value for hyper-threading, does not apply to total_procs unlike in python version
     pub hyperthreading_multiplier: u32,
+    /// Timestamp for when the machine was booted up
     pub boot_time: u32,
+    /// List of tags associated with this machine
     pub tags: Vec<String>,
+    /// Amount of free memory on the machine
     pub free_memory: u64,
+    /// Amount of free swap space on the machine
     pub free_swap: u64,
+    /// Total temporary storage available on the machine
     pub total_temp_storage: u64,
+    /// Amount of free temporary storage on the machine
     pub free_temp_storage: u64,
+    /// Current load on the machine
     pub load: u32,
 }
 
 pub struct MachineGpuStats {
+    /// Count of GPUs
     pub count: u32,
+    /// Total memory of all GPUs
     pub total_memory: u64,
+    /// Available free memory of all GPUs
     pub free_memory: u64,
+    /// Used memory by unit of each GPU, where the key in the HashMap is the unit ID, and the value is the used memory
     pub used_memory_by_unit: HashMap<u32, u64>,
 }
-
 pub trait MachineStatCollector {
-    /// Collects live information about the status of this machine
+    /// Collects information about the status of this machine
     fn collect_stats(&self) -> Result<MachineStat>;
-    /// Collects live information about the gpus on this machine
+
+    /// Collects information about the gpus on this machine
     fn collect_gpu_stats(&self) -> MachineGpuStats;
+
+    /// Up, Down, Rebooting...
     fn hardware_state(&self) -> &HardwareState;
+
+    /// List of attributes collected from the machine. Eg. SP_OS
     fn attributes(&self) -> &HashMap<String, String>;
+
+    /// Init NotInMyBackyard logic
     fn init_nimby(&self) -> Result<bool>;
 }

--- a/crates/rqd/src/running_frame.rs
+++ b/crates/rqd/src/running_frame.rs
@@ -67,7 +67,7 @@ impl Default for FrameStats {
             children: None,
             epoch_start_time: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_else(|_| std::time::Duration::from_secs(0))
                 .as_secs(),
         }
     }

--- a/crates/rqd/src/running_frame.rs
+++ b/crates/rqd/src/running_frame.rs
@@ -1,21 +1,149 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use dashmap::DashMap;
-use opencue_proto::report::RunningFrameInfo;
+use opencue_proto::{
+    report::{ChildrenProcStats, RunningFrameInfo},
+    rqd::RunFrame,
+};
+use uuid::Uuid;
 
 /// Wrapper around protobuf message RunningFrameInfo
-#[derive(Clone, Copy)]
-pub struct RunningFrame {}
+#[derive(Clone)]
+pub struct RunningFrame {
+    resource_id: String,
+    job_id: Uuid,
+    job_name: String,
+    frame_id: Uuid,
+    frame_name: String,
+    layer_id: Uuid,
+    show: String,
+    shot: String,
+    command: String,
+    user_name: String,
+    num_cores: i32,
+    num_gpus: i32,
+    frame_temp_dir: String,
+    log_path: String,
+    gid: i32,
+    ignore_nimby: bool,
+    environment: HashMap<String, String>,
+    /// additional data can be provided about the running frame
+    attributes: HashMap<String, String>,
+    frame_stats: Option<FrameStats>,
+}
 
-impl From<RunningFrameInfo> for RunningFrame {
-    fn from(frame_info: RunningFrameInfo) -> Self {
+#[derive(Clone)]
+pub struct FrameStats {
+    /// Maximum resident set size (KB) - maximum amount of physical memory used.
+    max_rss: u64,
+    /// Current resident set size (KB) - amount of physical memory currently in use.
+    rss: u64,
+    /// Maximum virtual memory size (KB) - maximum amount of virtual memory used.
+    max_vsize: u64,
+    /// Current virtual memory size (KB) - amount of virtual memory currently in use.
+    vsize: u64,
+    /// Last level cache utilization time.
+    llu_time: u64,
+    /// Maximum GPU memory usage (KB).
+    max_used_gpu_memory: u64,
+    /// Current GPU memory usage (KB).
+    used_gpu_memory: u64,
+    /// Additional data about the running frame's child processes.
+    pub children: Option<ChildrenProcStats>,
+    /// Unix timestamp denoting the start time of the frame process.
+    epoch_start_time: u64,
+}
+
+impl Default for FrameStats {
+    fn default() -> Self {
+        FrameStats {
+            max_rss: 0,
+            rss: 0,
+            max_vsize: 0,
+            vsize: 0,
+            llu_time: 0,
+            max_used_gpu_memory: 0,
+            used_gpu_memory: 0,
+            children: None,
+            epoch_start_time: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+}
+
+impl RunningFrame {
+    pub fn run(&self) {
+        // Windows, Linux or Docker
+        // Setup:
+        //  - tmp dir
+        //  - log path
+        //  - check and create user
+        //  - Create log stream
+        //
+        todo!()
+    }
+    pub fn kill(&self) {
         todo!()
     }
 }
 
 impl From<RunningFrame> for RunningFrameInfo {
     fn from(frame_info: RunningFrame) -> Self {
-        todo!()
+        let frame_stats = frame_info.frame_stats.unwrap_or(FrameStats::default());
+        RunningFrameInfo {
+            resource_id: frame_info.resource_id.clone(),
+            job_id: frame_info.job_id.to_string(),
+            job_name: frame_info.job_name.clone(),
+            frame_id: frame_info.frame_id.to_string(),
+            frame_name: frame_info.frame_name.clone(),
+            layer_id: frame_info.layer_id.to_string(),
+            num_cores: frame_info.num_cores,
+            start_time: frame_stats.epoch_start_time as i64,
+            max_rss: frame_stats.max_rss as i64,
+            rss: frame_stats.rss as i64,
+            max_vsize: frame_stats.max_vsize as i64,
+            vsize: frame_stats.vsize as i64,
+            attributes: frame_info.attributes.clone(),
+            llu_time: frame_stats.llu_time as i64,
+            num_gpus: frame_info.num_gpus,
+            max_used_gpu_memory: frame_stats.max_used_gpu_memory as i64,
+            used_gpu_memory: frame_stats.used_gpu_memory as i64,
+            children: frame_stats.children.clone(),
+        }
+    }
+}
+
+impl From<RunFrame> for RunningFrame {
+    fn from(run_frame: RunFrame) -> Self {
+        let job_id = run_frame.job_id();
+        let frame_id = run_frame.frame_id();
+        let layer_id = run_frame.layer_id();
+        RunningFrame {
+            resource_id: run_frame.resource_id,
+            job_id,
+            job_name: run_frame.job_name.clone(),
+            frame_id,
+            frame_name: run_frame.frame_name.clone(),
+            layer_id,
+            command: run_frame.command,
+            user_name: run_frame.user_name,
+            show: run_frame.show,
+            shot: run_frame.shot,
+            frame_temp_dir: run_frame.frame_temp_dir,
+            log_path: format!(
+                "{}/{}.{}.rqlog",
+                run_frame.log_dir, run_frame.job_name, run_frame.frame_name
+            ),
+            num_cores: run_frame.num_cores,
+            gid: run_frame.gid,
+            ignore_nimby: run_frame.ignore_nimby,
+            environment: run_frame.environment,
+            attributes: run_frame.attributes,
+            num_gpus: run_frame.num_gpus,
+            frame_stats: None,
+        }
     }
 }
 
@@ -24,7 +152,7 @@ impl From<RunningFrame> for RunningFrameInfo {
 /// without losing track of what's running
 #[derive(Clone)]
 pub struct RunningFrameCache {
-    cache: DashMap<String, RunningFrame>,
+    cache: DashMap<Uuid, Arc<RunningFrame>>,
 }
 
 impl RunningFrameCache {
@@ -34,11 +162,18 @@ impl RunningFrameCache {
         })
     }
 
+    /// Clones the contents of the cache into a vector
     pub fn into_running_frame_vec(&self) -> Vec<RunningFrameInfo> {
         self.cache
-            .clone()
-            .into_iter()
-            .map(|(_, running_frame)| running_frame.into())
+            .iter()
+            .map(|item| RunningFrameInfo::from(item.value().as_ref().clone()))
             .collect()
+    }
+
+    pub fn insert_running_frame(
+        &self,
+        running_frame: Arc<RunningFrame>,
+    ) -> Option<Arc<RunningFrame>> {
+        self.cache.insert(running_frame.frame_id, running_frame)
     }
 }

--- a/crates/rqd/src/running_frame.rs
+++ b/crates/rqd/src/running_frame.rs
@@ -120,6 +120,13 @@ impl From<RunFrame> for RunningFrame {
         let job_id = run_frame.job_id();
         let frame_id = run_frame.frame_id();
         let layer_id = run_frame.layer_id();
+        let log_path = std::path::Path::new(&run_frame.log_dir)
+            .join(format!(
+                "{}.{}.rqlog",
+                run_frame.job_name, run_frame.frame_name
+            ))
+            .to_string_lossy()
+            .to_string();
         RunningFrame {
             resource_id: run_frame.resource_id,
             job_id,
@@ -132,10 +139,7 @@ impl From<RunFrame> for RunningFrame {
             show: run_frame.show,
             shot: run_frame.shot,
             frame_temp_dir: run_frame.frame_temp_dir,
-            log_path: format!(
-                "{}/{}.{}.rqlog",
-                run_frame.log_dir, run_frame.job_name, run_frame.frame_name
-            ),
+            log_path,
             num_cores: run_frame.num_cores,
             gid: run_frame.gid,
             ignore_nimby: run_frame.ignore_nimby,
@@ -162,7 +166,8 @@ impl RunningFrameCache {
         })
     }
 
-    /// Clones the contents of the cache into a vector
+    /// Clones the contents of the cache into a vector. This method is potentially expensive,
+    /// it should only be used when a snapshot of the current state is required
     pub fn into_running_frame_vec(&self) -> Vec<RunningFrameInfo> {
         self.cache
             .iter()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced identifier handling with new methods for retrieving UUIDs from frame data.
	- Expanded monitoring capabilities with additional machine and GPU statistics for improved insight.
	- Introduced asynchronous frame launching to support non-blocking execution.
	- Added new fields to `RunningFrame` for comprehensive resource tracking and statistics.

- **Bug Fixes**
	- Improved error handling in UUID conversions to prevent panics.

- **Refactor**
	- Deprecated several legacy API fields to improve clarity.
	- Removed obsolete threading components, streamlining frame management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->