### PR TITLE
Implement kill_running_frame logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1640,8 @@ dependencies = [
  "dashmap",
  "deadpool-postgres",
  "futures",
+ "humantime",
+ "humantime-serde",
  "itertools 0.13.0",
  "miette",
  "nix",

--- a/config/rqd.fake_linux.yaml
+++ b/config/rqd.fake_linux.yaml
@@ -4,7 +4,7 @@ grpc.rqd_port: 8444
 grpc.cuebot_url: "0.0.0.0:4343"
 machine:
   facility: test
-  monitor_interval_seconds: 3
+  monitor_interval: 3s
   cpuinfo_path: "/Users/dtavares/dev/rust_opencue/crates/rqd/resources/cpuinfo/cpuinfo_srdsvr05_ht_12-6-2-2"
   distro_release_path: "/Users/dtavares/dev/rust_opencue/crates/rqd/resources/distro-release/rocky"
   proc_stat_path: "/Users/dtavares/dev/rust_opencue/crates/rqd/resources/proc/stat"
@@ -12,6 +12,9 @@ machine:
   temp_path: "/tmp"
 runner:
   snapshots_path: $HOME/.rqd/snapshots
+  kill_monitor_interval: 10s
+  kill_monitor_timeout: 60s
+  force_kill_after_timeout: true
 #   monitor_interval_seconds: 3
 #   use_ip_as_hostname: false
 #   nimby_mode: false

--- a/config/rqd.fake_linux.yaml
+++ b/config/rqd.fake_linux.yaml
@@ -10,6 +10,7 @@ machine:
   proc_stat_path: "/Users/dtavares/dev/rust_opencue/crates/rqd/resources/proc/stat"
   proc_loadavg_path: "/Users/dtavares/dev/rust_opencue/crates/rqd/resources/proc/loadavg"
   temp_path: "/tmp"
+  use_session_id_for_proc_lineage: true
 runner:
   snapshots_path: $HOME/.rqd/snapshots
   kill_monitor_interval: 10s

--- a/crates/dummy-cuebot/src/rqd_client.rs
+++ b/crates/dummy-cuebot/src/rqd_client.rs
@@ -71,4 +71,16 @@ impl DummyRqdClient {
             .into_diagnostic()
             .and(Ok(()))
     }
+
+    pub async fn kill_frame(&self, frame_id: String, reason: Option<String>) -> Result<()> {
+        let mut client = self.client.lock().await;
+        let mut request = pb::RqdStaticKillRunningFrameRequest::default();
+        request.frame_id = frame_id;
+        request.message = reason.unwrap_or("No reason".to_string());
+        client
+            .kill_running_frame(request)
+            .await
+            .into_diagnostic()
+            .and(Ok(()))
+    }
 }

--- a/crates/opencue-proto/src/lib.rs
+++ b/crates/opencue-proto/src/lib.rs
@@ -65,6 +65,12 @@ impl WithUuid for rqd::RqdStaticGetRunningFrameStatusRequest {
     }
 }
 
+impl WithUuid for rqd::RqdStaticKillRunningFrameRequest {
+    fn uuid(&self) -> Uuid {
+        to_uuid(&self.frame_id).unwrap_or(Uuid::nil())
+    }
+}
+
 pub fn to_uuid(stringified_id_from_protobuf: &str) -> Option<Uuid> {
     Uuid::parse_str(stringified_id_from_protobuf).ok()
 }

--- a/crates/rqd/Cargo.toml
+++ b/crates/rqd/Cargo.toml
@@ -43,6 +43,8 @@ itertools = "0.13.0"
 sysinfo = "0.33.1"
 nix = { version = "0.29", features = ["process", "signal"] }
 users = "0.11"
+humantime = "2.2.0"
+humantime-serde = "1.1.1"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/crates/rqd/resources/test_scripts/refuse_kill.sh
+++ b/crates/rqd/resources/test_scripts/refuse_kill.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Echo counter every 10 seconds and trap SIGTERM
+counter=0
+
+# Function to handle SIGTERM
+handle_signal() {
+    echo "Received $1. Not Exiting..."
+    counter=0
+    while true; do
+        echo "Killed Counter: $counter"
+        counter=$((counter + 1))
+        sleep 10
+
+        if [ $counter -ge 12 ]; then
+            echo "Reached 2 minutes runtime. Exiting..."
+            exit 0
+        fi
+    done
+    exit 0
+}
+
+# Set up trap for SIGTERM
+trap 'handle_signal SIGTERM' SIGTERM
+trap 'handle_signal SIGHUP' SIGHUP
+trap 'handle_signal SIGINT' SIGINT
+trap 'handle_signal SIGQUIT' SIGQUIT
+trap 'handle_signal SIGILL' SIGILL
+trap 'handle_signal SIGTRAP' SIGTRAP
+trap 'handle_signal SIGABRT' SIGABRT
+trap 'handle_signal SIGBUS' SIGBUS
+trap 'handle_signal SIGFPE' SIGFPE
+trap 'handle_signal SIGUSR1' SIGUSR1
+trap 'handle_signal SIGSEGV' SIGSEGV
+trap 'handle_signal SIGUSR2' SIGUSR2
+trap 'handle_signal SIGPIPE' SIGPIPE
+trap 'handle_signal SIGALRM' SIGALRM
+trap 'handle_signal SIGTERM' SIGTERM
+trap 'handle_signal EXIT' EXIT
+
+
+# Main loop
+while true; do
+    echo "Counter: $counter"
+    counter=$((counter + 1))
+    sleep 10
+done

--- a/crates/rqd/resources/test_scripts/script_wrapper.sh
+++ b/crates/rqd/resources/test_scripts/script_wrapper.sh
@@ -33,6 +33,8 @@ trap 'handle_signal HUP' SIGHUP
 # Start the command and get its PID
 eval "$1"
 exit_code=$?
+
+# Capture the pid of the command spawn by the eval expression
 command_pid=$!
 
 wait_for_output $exit_code

--- a/crates/rqd/resources/test_scripts/script_wrapper.sh
+++ b/crates/rqd/resources/test_scripts/script_wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source "$1"
+exit_code=$?
+echo $exit_code > $2
+exit $exit_code

--- a/crates/rqd/resources/test_scripts/script_wrapper.sh
+++ b/crates/rqd/resources/test_scripts/script_wrapper.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 
-source "$1"
+wait_for_output() {
+    echo "Writing output... $1"
+
+    # Wait for the command to complete
+    wait $command_pid
+    exit_code=$1
+
+    # Write the exit code to the specified file
+    echo $exit_code > output_signal.txt
+    exit $exit_code
+}
+
+# Function to handle signals
+handle_signal() {
+    local signal=$1
+    echo "Forwarding $signal signal to child process..." >&2
+    # Forward the signal to the child process if it exists
+    if [ -n "$command_pid" ] && kill -0 $command_pid 2>/dev/null; then
+        kill -$signal $command_pid
+        echo "waiting on child process... $command_pid"
+        wait_for_output $signal
+    fi
+    # Don't exit - let the script continue to monitor the child process
+}
+
+# Set up signal handling
+trap 'handle_signal TERM' SIGTERM
+trap 'handle_signal INT' SIGINT
+trap 'handle_signal HUP' SIGHUP
+
+# Start the command and get its PID
+eval "$1"
 exit_code=$?
-echo $exit_code > $2
-exit $exit_code
+command_pid=$!
+
+wait_for_output $exit_code

--- a/crates/rqd/src/config/config.rs
+++ b/crates/rqd/src/config/config.rs
@@ -62,6 +62,7 @@ pub struct MachineConfig {
     pub proc_loadavg_path: String,
     pub temp_path: String,
     pub core_multiplier: u32,
+    pub use_session_id_for_proc_lineage: bool,
 }
 
 impl Default for MachineConfig {
@@ -80,6 +81,7 @@ impl Default for MachineConfig {
             proc_loadavg_path: "/proc/loadavg".to_string(),
             temp_path: "/tmp".to_string(),
             core_multiplier: 100,
+            use_session_id_for_proc_lineage: true,
         }
     }
 }

--- a/crates/rqd/src/frame/cache.rs
+++ b/crates/rqd/src/frame/cache.rs
@@ -5,8 +5,6 @@ use dashmap::DashMap;
 use opencue_proto::report::RunningFrameInfo;
 use uuid::Uuid;
 
-use crate::system::machine::ProcessStats;
-
 use super::running_frame::RunningFrame;
 
 /// Keep track of all frames currently running

--- a/crates/rqd/src/frame/frame_cmd.rs
+++ b/crates/rqd/src/frame/frame_cmd.rs
@@ -66,6 +66,8 @@ impl FrameCmdBuilder {
     /// ```
     #[cfg(target_os = "linux")]
     pub fn with_taskset(&mut self, cpu_list: Vec<u32>) -> &mut Self {
+        use itertools::Itertools;
+
         let taskset_list = cpu_list.into_iter().map(|v| v.to_string()).join(",");
         self.cmd.arg("taskset").arg("-p").arg(taskset_list.as_str());
         self

--- a/crates/rqd/src/frame/manager.rs
+++ b/crates/rqd/src/frame/manager.rs
@@ -1,11 +1,17 @@
+use chrono::DateTime;
 use miette::{Diagnostic, Result, miette};
 use opencue_proto::{
     host::HardwareState,
     rqd::{RunFrame, run_frame},
 };
-use std::{fs, sync::Arc};
+use std::{
+    fs,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use thiserror::Error;
-use tracing::{error, warn};
+use tokio::time;
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::{config::config::Config, servant::rqd_servant::MachineImpl};
@@ -265,11 +271,137 @@ impl FrameManager {
                 "Not launching, host HardwareState is not Up".to_string(),
             ))?
         }
+
         // Nimby locked
         if self.machine.nimby_locked().await && !ignore_nimby {
             Err(FrameManagerError::NimbyLocked)?
         }
         Ok(())
+    }
+
+    pub fn get_running_frame(&self, frame_id: &Uuid) -> Option<Arc<RunningFrame>> {
+        self.frame_cache
+            .get(frame_id)
+            .as_ref()
+            .map(|f| Arc::clone(f))
+    }
+
+    /// Kills a running frame on this host.
+    ///
+    /// This function attempts to find and terminate a running frame by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `frame_id` - The UUID identifying the frame to kill
+    /// * `reason` - A string describing why the frame is being killed
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(()))` if the frame was found and killed successfully
+    /// * `Ok(None)` if no frame with the given ID was found
+    /// * `Err(miette::Error)` if frame cannot be killed, possibly a precondition wasn't met
+    ///     - Frame existed but wasn't running
+    ///     - Frame has alredy been killed
+    pub async fn kill_running_frame(&self, frame_id: &Uuid, reason: String) -> Result<Option<()>> {
+        match self.get_running_frame(frame_id) {
+            Some(running_frame) => {
+                let pid = running_frame.get_pid_to_kill();
+                if let Ok(frame_pid) = pid {
+                    info!(
+                        "Killing frame {running_frame}({frame_pid}) by request.\n\
+                        Reason: {reason}"
+                    );
+                    self.machine.kill(frame_pid).await?;
+                    self.monitor_killed_frame(frame_pid, &running_frame);
+
+                    Ok(Some(()))
+                } else {
+                    Err(miette!(
+                        "Kill frame with invalid State. Frame {running_frame} exists but has \
+                        no pid assigned to it"
+                    ))
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Monitors a killed frame to ensure it fully terminates.
+    ///
+    /// After a frame is killed, this function spawns a background task that periodically checks
+    /// if the process and its children have fully terminated. It will log an error if processes
+    /// are still running after the monitoring time limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `frame_pid` - The process ID of the killed frame
+    /// * `running_frame` - Reference to the RunningFrame object that was killed
+    fn monitor_killed_frame(&self, frame_pid: u32, running_frame: &RunningFrame) {
+        let interval_seconds = self.config.runner.kill_monitor_interval.as_secs();
+        let mut monitor_limit_seconds = self.config.runner.kill_monitor_timeout.as_secs();
+        let force_kill = self.config.runner.force_kill_after_timeout;
+        let mut interval = time::interval(self.config.runner.kill_monitor_interval);
+        let kill_request_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| {
+                let secs = d.as_secs();
+                let dt = DateTime::from_timestamp(secs as i64, 0).unwrap_or_default();
+                dt.format("%Y-%m-%d %H:%M:%S").to_string()
+            })
+            .unwrap_or_else(|_| "invalid time".to_string());
+        let job_str = format!("{}", running_frame);
+        let machine = Arc::clone(&self.machine);
+
+        tokio::spawn(async move {
+            loop {
+                interval.tick().await;
+
+                let active_lineage = machine.get_active_proc_lineage(frame_pid).await;
+                if let Some(mut lineage) = active_lineage {
+                    lineage.push(frame_pid);
+                    // Check limit before decrementing as tick() returns immediately on the first call
+                    if monitor_limit_seconds <= 0 {
+                        if force_kill {
+                            match machine.force_kill(&lineage).await {
+                                Ok(()) => info!(
+                                    "Kill timeout for {}. Used force_kill on pending processes. \
+                                    Kill has been requested at {} but proc({}) lineage is still active: {:?}.",
+                                    job_str, kill_request_time, frame_pid, lineage
+                                ),
+                                Err(err) => warn!(
+                                    "Failed to force_kill {} lineage = {:?}. {}",
+                                    job_str, lineage, err
+                                ),
+                            }
+                        } else {
+                            error!(
+                                "Gave up waiting on {} termination. \
+                                Kill has been requested at {} but proc({}) lineage is still active: {:?}.",
+                                job_str, kill_request_time, frame_pid, lineage
+                            );
+                        }
+                        break;
+                    } else {
+                        info!(
+                            "Frame {} still being killed. \
+                            Kill has been requested at {} but proc({}) lineage is still active: {:?}.",
+                            job_str, kill_request_time, frame_pid, lineage
+                        );
+                    }
+                } else {
+                    break;
+                }
+
+                monitor_limit_seconds -= interval_seconds;
+            }
+        });
+        // if let Some(pids_to_kill) = active_lineage {
+        //     if self.config.runner.kill_force_after_limit {
+        //         tokio::spawn(async move {
+        //             self.machine.force_kill(pids_to_kill).await;
+        //         });
+        //     }
+        // }
     }
 }
 

--- a/crates/rqd/src/frame/running_frame.rs
+++ b/crates/rqd/src/frame/running_frame.rs
@@ -16,9 +16,10 @@ use std::{
 use std::{os::unix::process::ExitStatusExt, sync::mpsc};
 use std::{process::Stdio, thread};
 
+use chrono::DateTime;
 use tracing::{error, info, warn};
 
-use crate::{frame::frame_cmd::FrameCmdBuilder, system::machine::ProcessStats};
+use crate::{frame::frame_cmd::FrameCmdBuilder, system::manager::ProcessStats};
 
 use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, System};
@@ -48,6 +49,7 @@ pub struct RunningFrame {
     raw_stdout_path: String,
     raw_stderr_path: String,
     pub exit_file_path: String,
+    pub entrypoint_file_path: String,
     state: Mutex<FrameState>,
 }
 
@@ -60,44 +62,29 @@ pub enum FrameState {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreatedState {
+    // Attention: Recovered frames will never have a joinHandle
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
-    launch_thread_handle: Arc<Option<JoinHandle<()>>>,
+    launch_thread_handle: Option<JoinHandle<()>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RunningState {
-    pid: Option<u32>,
+    pid: u32,
     start_time: SystemTime,
+    // Attention: Recovered frames will never have a joinHandle
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
-    launch_thread_handle: Arc<Option<JoinHandle<()>>>,
-}
-
-impl RunningState {
-    fn into_finished(
-        &self,
-        exit_code: i32,
-        exit_signal: Option<i32>,
-        end_time: SystemTime,
-    ) -> FinishedState {
-        FinishedState {
-            pid: self.pid,
-            launch_thread_handle: Arc::clone(&self.launch_thread_handle),
-            start_time: self.start_time,
-            end_time,
-            exit_code,
-            exit_signal,
-        }
-    }
+    launch_thread_handle: Option<JoinHandle<()>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FinishedState {
-    pub pid: Option<u32>,
+    pub pid: u32,
+    // Attention: Recovered frames will never have a joinHandle
     #[serde(skip_serializing)]
     #[serde(skip_deserializing)]
-    launch_thread_handle: Arc<Option<JoinHandle<()>>>,
+    launch_thread_handle: Option<JoinHandle<()>>,
     pub start_time: SystemTime,
     pub end_time: SystemTime,
     pub exit_code: i32,
@@ -152,6 +139,13 @@ impl RunningFrame {
             ))
             .to_string_lossy()
             .to_string();
+        let entrypoint_file_path = std::path::Path::new(&request.log_dir)
+            .join(format!(
+                "{}.{}.{}.sh",
+                request.job_name, request.frame_name, resource_id
+            ))
+            .to_string_lossy()
+            .to_string();
         let env_vars = Self::setup_env_vars(&config, &request, hostname.clone(), log_path.clone());
 
         RunningFrame {
@@ -170,8 +164,9 @@ impl RunningFrame {
             raw_stdout_path,
             raw_stderr_path,
             exit_file_path,
+            entrypoint_file_path,
             state: Mutex::new(FrameState::Created(CreatedState {
-                launch_thread_handle: Arc::new(None),
+                launch_thread_handle: None,
             })),
         }
     }
@@ -183,7 +178,7 @@ impl RunningFrame {
             FrameState::Running(_) => None,
             FrameState::Finished(ref finished_state) => Some(FinishedState {
                 pid: finished_state.pid,
-                launch_thread_handle: Arc::clone(&finished_state.launch_thread_handle),
+                launch_thread_handle: None,
                 start_time: finished_state.start_time,
                 end_time: finished_state.end_time,
                 exit_code: finished_state.exit_code,
@@ -204,11 +199,11 @@ impl RunningFrame {
         let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
         match *state {
             FrameState::Created(ref mut created_state) => {
-                created_state.launch_thread_handle = Arc::new(Some(thread_handle));
+                created_state.launch_thread_handle = Some(thread_handle);
                 Ok(())
             }
             FrameState::Running(ref mut running_state) => {
-                running_state.launch_thread_handle = Arc::new(Some(thread_handle));
+                running_state.launch_thread_handle = Some(thread_handle);
                 Ok(())
             }
             FrameState::Finished(_) => Err(miette!("Invalid State. Frame has already finished")),
@@ -225,14 +220,21 @@ impl RunningFrame {
     /// which can later be used to determine if the frame succeeded or failed.
     pub fn finish(&self, exit_code: i32, exit_signal: Option<i32>) -> Result<()> {
         let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
-        match *state {
+        match &mut *state {
             FrameState::Created(_) => Err(miette!("Invalid State. Frame {} hasn't started", self)),
-            FrameState::Running(ref mut running_state) => {
-                *state = FrameState::Finished(running_state.into_finished(
+            FrameState::Running(running_state) => {
+                // Create a new FinishedState with the current running state values
+                let finished_state = FinishedState {
+                    pid: running_state.pid,
+                    launch_thread_handle: running_state.launch_thread_handle.take(),
+                    start_time: running_state.start_time,
+                    end_time: SystemTime::now(),
                     exit_code,
                     exit_signal,
-                    SystemTime::now(),
-                ));
+                };
+
+                // Replace state with the new FinishedState
+                *state = FrameState::Finished(finished_state);
                 Ok(())
             }
             FrameState::Finished(_) => Err(miette!(
@@ -245,16 +247,16 @@ impl RunningFrame {
     fn start(&self, pid: u32) -> Result<()> {
         let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
 
-        match *state {
-            FrameState::Created(ref created_state) => {
+        match &mut *state {
+            FrameState::Created(created_state) => {
                 *state = FrameState::Running(RunningState {
-                    pid: Some(pid),
+                    pid,
                     start_time: SystemTime::now(),
-                    launch_thread_handle: Arc::clone(&created_state.launch_thread_handle),
+                    launch_thread_handle: created_state.launch_thread_handle.take(),
                 });
                 Ok(())
             }
-            FrameState::Running(ref running_state) => Err(miette!(
+            FrameState::Running(running_state) => Err(miette!(
                 "Invalid State. Frame {} has already started {:?}",
                 self,
                 running_state
@@ -378,7 +380,8 @@ impl RunningFrame {
 
         logger.writeln(self.write_header().as_str());
 
-        let mut command = FrameCmdBuilder::new(&self.config.shell_path);
+        let mut command =
+            FrameCmdBuilder::new(&self.config.shell_path, self.entrypoint_file_path.clone());
         if self.config.desktop_mode {
             command.with_nice();
         }
@@ -388,11 +391,11 @@ impl RunningFrame {
         let raw_stdout = Self::setup_raw_fd(&self.raw_stdout_path)?;
         let raw_stderr = Self::setup_raw_fd(&self.raw_stderr_path)?;
 
-        let cmd = command
+        let (cmd, cmd_str) = command
             .with_frame_cmd(self.request.command.clone())
             .with_exit_file(self.exit_file_path.clone())
-            .build()
-            .envs(&self.env_vars)
+            .build()?;
+        cmd.envs(&self.env_vars)
             .current_dir(&self.config.temp_path)
             // An spawn job should be able to run independent of rqd.
             // If this process dies, the process continues to write to its assigned file
@@ -404,16 +407,7 @@ impl RunningFrame {
             cmd.uid(self.uid);
         }
 
-        logger.writeln(
-            format!(
-                "full_cmd = {} {}",
-                self.config.shell_path,
-                cmd.get_args()
-                    .map(|s| s.to_str().unwrap_or("#?#"))
-                    .join(" ")
-            )
-            .as_str(),
-        );
+        logger.writeln(format!("Running {}: \n{}", self.entrypoint_file_path, cmd_str).as_str());
 
         // Launch frame process
         let mut child = cmd.spawn().into_diagnostic().map_err(|e| {
@@ -453,10 +447,14 @@ impl RunningFrame {
         // If a process got terminated by a signal, set the exit_code to 1
         let exit_code = output.code().unwrap_or(1);
         let msg = match exit_code {
-            0 => format!("Frame {} finished successfully with pid={}", self, pid),
+            0 => format!("Frame {}(pid={}) finished successfully", self, pid),
             _ => format!(
-                "Frame {} finished with pid={} and exit_code={}. Log: {}",
-                self, pid, exit_code, self.log_path
+                "Frame {}(pid={}) finished with exit_code={} and exit_signal={}. Log: {}",
+                self,
+                pid,
+                exit_code,
+                exit_signal.unwrap_or(0),
+                self.log_path,
             ),
         };
         info!(msg);
@@ -560,8 +558,8 @@ impl RunningFrame {
         let state = self.state.lock().unwrap_or_else(|err| err.into_inner());
         match *state {
             FrameState::Created(_) => None,
-            FrameState::Running(ref running_state) => running_state.pid,
-            FrameState::Finished(ref finished_state) => finished_state.pid,
+            FrameState::Running(ref running_state) => Some(running_state.pid),
+            FrameState::Finished(ref finished_state) => Some(finished_state.pid),
         }
     }
 
@@ -671,8 +669,43 @@ impl RunningFrame {
         Ok(())
     }
 
-    pub fn kill(&self) {
-        todo!()
+    /// Retrieves the process ID (PID) that should be killed when terminating this frame
+    ///
+    /// # Returns
+    /// Returns a `Result` containing the PID if the frame is in a running state
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The frame has not been started yet (is in Created state)
+    /// - The frame has already finished (is in Finished state)
+    ///
+    /// # Details
+    /// This method safely accesses the thread-protected state to retrieve
+    /// the current PID of the running frame process. A warning is logged
+    /// if the frame doesn't have an associated thread handle.
+    pub fn get_pid_to_kill(&self) -> Result<u32> {
+        let lock = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match *lock {
+            FrameState::Created(_) => Err(miette!("Frame has been created but hasn't started yet")),
+            FrameState::Running(ref running_state) => Ok(running_state.pid),
+            FrameState::Finished(ref finished_state) => Err(miette!(
+                "Frame has already terminated at {} with exit_code={} and exit_signal={:?}",
+                finished_state
+                    .end_time
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| {
+                        let secs = d.as_secs();
+                        let dt = DateTime::from_timestamp(secs as i64, 0).unwrap_or_default();
+                        dt.format("%Y-%m-%d %H:%M:%S").to_string()
+                    })
+                    .unwrap_or_else(|_| "invalid time".to_string()),
+                finished_state.exit_code,
+                finished_state.exit_signal
+            )),
+        }
     }
 
     fn setup_raw_fd(path: &str) -> Result<RawFd> {
@@ -832,18 +865,14 @@ impl RunningFrame {
             FrameState::Created(_) => false,
             FrameState::Running(_) => false,
             FrameState::Finished(ref finished_state) => {
-                let thread_finished = match &*finished_state.launch_thread_handle {
+                let thread_finished = match &finished_state.launch_thread_handle {
                     Some(handle) => handle.is_finished(),
                     None => {
-                        info!("Thread handle missing");
+                        warn!("Thread handle missing");
                         true
                     }
                 };
-                let pid_running = finished_state
-                    .pid
-                    .map(|pid| Self::is_process_running(pid))
-                    .clone()
-                    .unwrap_or(false);
+                let pid_running = Self::is_process_running(finished_state.pid);
                 thread_finished && !pid_running
             }
         }

--- a/crates/rqd/src/frame/running_frame.rs
+++ b/crates/rqd/src/frame/running_frame.rs
@@ -373,7 +373,6 @@ impl RunningFrame {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn run_inner(&self, logger: FrameLogger) -> Result<(i32, Option<i32>)> {
-        use itertools::Itertools;
         use nix::libc;
         use tracing::trace;
 

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -384,7 +384,7 @@ pub trait Machine {
     ///  * [EINVAL] The value of the sig argument is an invalid or unsupported signal number.
     ///  * [EPERM] The process does not have permission to send the signal to any receiving process.
     ///  * [ESRCH] No process or process group can be found corresponding to that specified by pid.
-    async fn kill(&self, pid: u32) -> Result<()>;
+    async fn kill_session(&self, pid: u32, force: bool) -> Result<()>;
 
     async fn force_kill(&self, pids: &Vec<u32>) -> Result<()>;
 
@@ -524,9 +524,13 @@ impl Machine for MachineMonitor {
             .unwrap_or("noname".to_string())
     }
 
-    async fn kill(&self, pid: u32) -> Result<()> {
+    async fn kill_session(&self, pid: u32, force: bool) -> Result<()> {
         let system = self.system_manager.lock().await;
-        system.kill(pid)
+        if force {
+            system.force_kill_session(pid)
+        } else {
+            system.kill_session(pid)
+        }
     }
 
     async fn force_kill(&self, pids: &Vec<u32>) -> Result<()> {

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -149,7 +149,7 @@ impl MachineMonitor {
 
     async fn update_procs(&self) {
         let system_manager = self.system_manager.lock().await;
-        system_manager.refresh_procs(self.running_frames_cache.pids());
+        system_manager.refresh_procs();
     }
 
     async fn collect_and_send_host_report(&self) -> Result<()> {

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -1,17 +1,12 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Instant,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use bytesize::KIB;
-use miette::{Diagnostic, IntoDiagnostic, Result, miette};
+use miette::{IntoDiagnostic, Result, miette};
 use opencue_proto::{
     host::HardwareState,
-    report::{ChildrenProcStats, CoreDetail, RenderHost},
+    report::{CoreDetail, RenderHost},
 };
-use thiserror::Error;
 use tokio::{
     select,
     sync::{
@@ -28,11 +23,11 @@ use crate::{
     frame::{cache::RunningFrameCache, running_frame::RunningFrame},
     report_client::{ReportClient, ReportInterface},
 };
-use serde::{Deserialize, Serialize};
 
-use super::unix::UnixSystem;
-
-type SystemControllerType = Box<dyn SystemController + Sync + Send>;
+use super::{
+    manager::{ReservationError, SystemManagerType},
+    unix::UnixSystem,
+};
 
 /// Constantly monitor the state of this machine and report back to Cuebot
 ///
@@ -55,7 +50,7 @@ type SystemControllerType = Box<dyn SystemController + Sync + Send>;
 pub struct MachineMonitor {
     maching_config: MachineConfig,
     report_client: Arc<ReportClient>,
-    pub system_controller: Mutex<SystemControllerType>,
+    pub system_manager: Mutex<SystemManagerType>,
     pub running_frames_cache: Arc<RunningFrameCache>,
     core_state: Arc<Mutex<CoreDetail>>,
     last_host_state: Arc<Mutex<Option<RenderHost>>>,
@@ -70,12 +65,12 @@ impl MachineMonitor {
         report_client: Arc<ReportClient>,
         running_frames_cache: Arc<RunningFrameCache>,
     ) -> Result<Self> {
-        let system_controller: SystemControllerType = Box::new(UnixSystem::init(&config.machine)?);
-        // TODO: identify which OS is running and initialize stats_collector accordingly
+        let system_manager: SystemManagerType = Box::new(UnixSystem::init(&config.machine)?);
+        // TODO: identify which OS is running and initialize system_manager accordingly
         Ok(Self {
             maching_config: config.machine.clone(),
             report_client,
-            system_controller: Mutex::new(system_controller),
+            system_manager: Mutex::new(system_manager),
             running_frames_cache,
             core_state: Arc::new(Mutex::new(CoreDetail::default())),
             last_host_state: Arc::new(Mutex::new(None)),
@@ -87,9 +82,9 @@ impl MachineMonitor {
     pub async fn start(&self) -> Result<()> {
         let report_client = self.report_client.clone();
 
-        let stats_collector_lock = self.system_controller.lock().await;
-        let host_state = Self::inspect_host_state(&self.maching_config, &stats_collector_lock)?;
-        drop(stats_collector_lock);
+        let system_lock = self.system_manager.lock().await;
+        let host_state = Self::inspect_host_state(&self.maching_config, &system_lock)?;
+        drop(system_lock);
 
         self.last_host_state
             .lock()
@@ -113,9 +108,7 @@ impl MachineMonitor {
             .send_start_up_report(host_state, initial_core_state)
             .await?;
 
-        let mut interval = time::interval(time::Duration::from_secs(
-            self.maching_config.monitor_interval_seconds,
-        ));
+        let mut interval = time::interval(self.maching_config.monitor_interval);
 
         let (sender, mut receiver) = oneshot::channel::<()>();
         let mut interrupt_lock = self.interrupt.lock().await;
@@ -155,15 +148,15 @@ impl MachineMonitor {
     }
 
     async fn update_procs(&self) {
-        let system_controller = self.system_controller.lock().await;
-        system_controller.update_procs(self.running_frames_cache.pids());
+        let system_manager = self.system_manager.lock().await;
+        system_manager.refresh_procs(self.running_frames_cache.pids());
     }
 
     async fn collect_and_send_host_report(&self) -> Result<()> {
         let report_client = self.report_client.clone();
-        let system_controller = self.system_controller.lock().await;
-        let host_state = Self::inspect_host_state(&self.maching_config, &system_controller)?;
-        drop(system_controller);
+        let system_manager = self.system_manager.lock().await;
+        let host_state = Self::inspect_host_state(&self.maching_config, &system_manager)?;
+        drop(system_manager);
         // Store the last host_state on self
         let mut self_host_state_lock = self.last_host_state.lock().await;
         self_host_state_lock.replace(host_state.clone());
@@ -184,7 +177,7 @@ impl MachineMonitor {
     }
 
     async fn monitor_running_frames(&self) -> Result<()> {
-        let system_monitor = self.system_controller.lock().await;
+        let system_monitor = self.system_manager.lock().await;
         let mut finished_frames: Vec<Arc<RunningFrame>> = Vec::new();
 
         self.running_frames_cache.retain(|_, running_frame| {
@@ -276,14 +269,14 @@ impl MachineMonitor {
 
     fn inspect_host_state(
         config: &MachineConfig,
-        stats_collector: &SystemControllerType,
+        system: &SystemManagerType,
     ) -> Result<RenderHost> {
-        let stats = stats_collector.collect_stats()?;
-        let gpu_stats = stats_collector.collect_gpu_stats();
+        let stats = system.collect_stats()?;
+        let gpu_stats = system.collect_gpu_stats();
 
         Ok(RenderHost {
             name: stats.hostname,
-            nimby_enabled: stats_collector.init_nimby()?,
+            nimby_enabled: system.init_nimby()?,
             nimby_locked: false, // TODO: implement nimby lock
             facility: config.facility.clone(),
             num_procs: stats.num_procs as i32,
@@ -297,8 +290,8 @@ impl MachineMonitor {
             load: stats.load as i32,
             boot_time: stats.boot_time as i32,
             tags: stats.tags,
-            state: stats_collector.hardware_state().clone() as i32,
-            attributes: stats_collector.attributes().clone(),
+            state: system.hardware_state().clone() as i32,
+            attributes: system.attributes().clone(),
             num_gpus: gpu_stats.count as i32,
             free_gpu_mem: gpu_stats.free_memory as i64,
             total_gpu_mem: gpu_stats.total_memory as i64,
@@ -306,6 +299,7 @@ impl MachineMonitor {
     }
 }
 
+/// Performe actions on a machine with an async lock
 #[async_trait]
 pub trait Machine {
     async fn hardware_state(&self) -> Option<HardwareState>;
@@ -383,6 +377,20 @@ pub trait Machine {
     async fn create_user_if_unexisting(&self, username: &str, uid: u32, gid: u32) -> Result<u32>;
 
     async fn get_host_name(&self) -> String;
+
+    /// Send a signal to kill a process
+    ///
+    /// # Returns Errors:
+    ///  * [EINVAL] The value of the sig argument is an invalid or unsupported signal number.
+    ///  * [EPERM] The process does not have permission to send the signal to any receiving process.
+    ///  * [ESRCH] No process or process group can be found corresponding to that specified by pid.
+    async fn kill(&self, pid: u32) -> Result<()>;
+
+    async fn force_kill(&self, pids: &Vec<u32>) -> Result<()>;
+
+    /// Check if this pid and any of its children are still active
+    /// Returns the list of active children, and none if the pid itself is not active
+    async fn get_active_proc_lineage(&self, pid: u32) -> Option<Vec<u32>>;
 }
 
 #[async_trait]
@@ -412,8 +420,8 @@ impl Machine for MachineMonitor {
     ) -> Result<Option<Vec<u32>>> {
         // Reserve cores on the socket level
         let cores_result = if with_affinity {
-            let mut stats_collector = self.system_controller.lock().await;
-            stats_collector
+            let mut system_lock = self.system_manager.lock().await;
+            system_lock
                 .reserve_cores(num_cores, resource_id)
                 .into_diagnostic()
                 .map(|v| Some(v))
@@ -440,8 +448,8 @@ impl Machine for MachineMonitor {
     ) -> Result<Vec<u32>> {
         // Reserve cores on the socket level
         let cores_result = {
-            let mut stats_collector = self.system_controller.lock().await;
-            stats_collector
+            let mut system_lock = self.system_manager.lock().await;
+            system_lock
                 .reserve_cores_by_id(cpu_list, resource_id)
                 .into_diagnostic()
         };
@@ -458,9 +466,9 @@ impl Machine for MachineMonitor {
 
     async fn release_cpus(&self, procs: &Vec<u32>) {
         {
-            let mut stats_collector = self.system_controller.lock().await;
+            let mut system = self.system_manager.lock().await;
             for core_id in procs {
-                if let Err(err) = stats_collector.release_core(core_id) {
+                if let Err(err) = system.release_core(core_id) {
                     match err {
                         ReservationError::NotFoundError(_) => {
                             warn!("Failed to release proc {core_id}. Reservation not found")
@@ -504,8 +512,8 @@ impl Machine for MachineMonitor {
     }
 
     async fn create_user_if_unexisting(&self, username: &str, uid: u32, gid: u32) -> Result<u32> {
-        let stats_collector = self.system_controller.lock().await;
-        stats_collector.create_user_if_unexisting(username, uid, gid)
+        let system = self.system_manager.lock().await;
+        system.create_user_if_unexisting(username, uid, gid)
     }
 
     async fn get_host_name(&self) -> String {
@@ -515,201 +523,19 @@ impl Machine for MachineMonitor {
             .map(|h| h.name.clone())
             .unwrap_or("noname".to_string())
     }
-}
 
-/// Represents attributes on a machine that should never change withour restarting the
-/// entire servive
-#[derive(Clone, Debug)]
-pub struct MachineStat {
-    /// Machine name
-    pub hostname: String,
-    /// Total number of processing units (also known as virtual cores)
-    pub num_procs: u32,
-    /// Total amount of memory on the machine
-    pub total_memory: u64,
-    /// Total amount of swap space on the machine
-    pub total_swap: u64,
-    /// Total number of physical cores (also known as sockets)
-    pub num_sockets: u32,
-    /// Number of cores per processor unit
-    pub cores_per_proc: u32,
-    /// Multiplier value for hyper-threading, does not apply to total_procs unlike in python version
-    pub hyperthreading_multiplier: u32,
-    /// Timestamp for when the machine was booted up
-    pub boot_time: u32,
-    /// List of tags associated with this machine
-    pub tags: Vec<String>,
-    /// Amount of available memory on the machine. For Linux/Macos Free + Cached
-    pub available_memory: u64,
-    /// Amount of free swap space on the machine
-    pub free_swap: u64,
-    /// Total temporary storage available on the machine
-    pub total_temp_storage: u64,
-    /// Amount of free temporary storage on the machine
-    pub free_temp_storage: u64,
-    /// Current load on the machine
-    pub load: u32,
-}
-
-pub struct MachineGpuStats {
-    /// Count of GPUs
-    pub count: u32,
-    /// Total memory of all GPUs
-    pub total_memory: u64,
-    /// Available free memory of all GPUs
-    pub free_memory: u64,
-    /// Used memory by unit of each GPU, where the key in the HashMap is the unit ID, and the value is the used memory
-    pub used_memory_by_unit: HashMap<u32, u64>,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ProcessStats {
-    /// Maximum resident set size (KB) - maximum amount of physical memory used.
-    pub max_rss: u64,
-    /// Current resident set size (KB) - amount of physical memory currently in use.
-    pub rss: u64,
-    /// Maximum virtual memory size (KB) - maximum amount of virtual memory used.
-    pub max_vsize: u64,
-    /// Current virtual memory size (KB) - amount of virtual memory currently in use.
-    pub vsize: u64,
-    /// Last time the log was updated
-    pub llu_time: u64,
-    /// Maximum GPU memory usage (KB).
-    pub max_used_gpu_memory: u64,
-    /// Current GPU memory usage (KB).
-    pub used_gpu_memory: u64,
-    /// Additional data about the running frame's child processes.
-    pub children: Option<ChildrenProcStats>,
-    /// Unix timestamp denoting the start time of the frame process.
-    pub epoch_start_time: u64,
-}
-
-impl Default for ProcessStats {
-    fn default() -> Self {
-        ProcessStats {
-            max_rss: 0,
-            rss: 0,
-            max_vsize: 0,
-            vsize: 0,
-            llu_time: 0,
-            max_used_gpu_memory: 0,
-            used_gpu_memory: 0,
-            children: None,
-            epoch_start_time: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_else(|_| std::time::Duration::from_secs(0))
-                .as_secs(),
-        }
-    }
-}
-
-/// Get the max between two u64s
-fn max_u64(left: u64, right: u64) -> u64 {
-    (left > right).then(|| left).unwrap_or(right)
-}
-
-impl ProcessStats {
-    fn update(&mut self, new: Self) {
-        *self = ProcessStats {
-            max_rss: max_u64(new.max_rss, self.max_rss),
-            max_vsize: max_u64(new.max_vsize, self.max_vsize),
-            max_used_gpu_memory: max_u64(new.max_used_gpu_memory, self.max_used_gpu_memory),
-            ..new
-        };
-    }
-}
-
-pub trait SystemController {
-    /// Collects information about the status of this machine
-    fn collect_stats(&self) -> Result<MachineStat>;
-
-    /// Collects information about the gpus on this machine
-    fn collect_gpu_stats(&self) -> MachineGpuStats;
-
-    /// Up, Down, Rebooting...
-    fn hardware_state(&self) -> &HardwareState;
-
-    /// List of attributes collected from the machine. Eg. SP_OS
-    fn attributes(&self) -> &HashMap<String, String>;
-
-    /// Init NotInMyBackyard logic
-    fn init_nimby(&self) -> Result<bool>;
-
-    /// Returns a map of cores per socket that are not reserved
-    fn cpu_stat(&self) -> CpuStat;
-
-    /// Reserver a number of cores.
-    ///
-    /// # Returns:
-    ///
-    /// * Vector of core ids
-    fn reserve_cores(&mut self, count: u32, frame_id: Uuid) -> Result<Vec<u32>, ReservationError>;
-
-    /// Reserver specific cores by id.
-    ///
-    /// # Returns:
-    ///
-    /// * Vector of core ids
-    fn reserve_cores_by_id(
-        &mut self,
-        cpu_list: &Vec<u32>,
-        resource_id: Uuid,
-    ) -> Result<Vec<u32>, ReservationError>;
-
-    /// Release a core
-    fn release_core(&mut self, core_id: &u32) -> Result<(), ReservationError>;
-
-    /// Creates an user if it doesn't already exist
-    fn create_user_if_unexisting(&self, username: &str, uid: u32, gid: u32) -> Result<u32>;
-
-    /// Collects stats of a process
-    fn collect_proc_stats(&self, pid: u32, log_path: String) -> Result<Option<ProcessStats>>;
-
-    /// Update info about procs currently active
-    fn update_procs(&self, pids: Vec<u32>);
-}
-
-#[derive(Debug, Clone, Diagnostic, Error)]
-pub enum ReservationError {
-    #[error("No resources available to be reserved")]
-    NotEnoughResourcesAvailable,
-
-    #[error("Could not find resource with provided key: {0}")]
-    NotFoundError(u32),
-}
-
-#[derive(Debug, Clone)]
-pub struct CpuStat {
-    /// List of cores currently reserved
-    pub reserved_cores_by_physid: HashMap<u32, CoreReservation>,
-    pub available_cores: u32,
-}
-
-#[derive(Debug, Clone)]
-pub struct CoreReservation {
-    pub reserved_cores: HashSet<u32>,
-    pub reserver_id: Uuid,
-    pub start_time: Instant,
-}
-
-impl CoreReservation {
-    pub fn new(reserver_id: Uuid) -> Self {
-        CoreReservation {
-            reserved_cores: HashSet::new(),
-            reserver_id,
-            start_time: Instant::now(),
-        }
+    async fn kill(&self, pid: u32) -> Result<()> {
+        let system = self.system_manager.lock().await;
+        system.kill(pid)
     }
 
-    pub fn iter(&self) -> std::collections::hash_set::Iter<'_, u32> {
-        self.reserved_cores.iter()
+    async fn force_kill(&self, pids: &Vec<u32>) -> Result<()> {
+        let system = self.system_manager.lock().await;
+        system.force_kill(pids)
     }
 
-    pub fn insert(&mut self, core_id: u32) -> bool {
-        self.reserved_cores.insert(core_id)
-    }
-
-    pub fn remove(&mut self, core_id: &u32) -> bool {
-        self.reserved_cores.remove(core_id)
+    async fn get_active_proc_lineage(&self, pid: u32) -> Option<Vec<u32>> {
+        let system = self.system_manager.lock().await;
+        system.get_proc_lineage(pid)
     }
 }

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -1,0 +1,220 @@
+use std::{
+    collections::{HashMap, HashSet},
+    time::Instant,
+};
+
+use miette::{Diagnostic, Result};
+use opencue_proto::{host::HardwareState, report::ChildrenProcStats};
+use thiserror::Error;
+use tracing::error;
+use uuid::Uuid;
+
+use serde::{Deserialize, Serialize};
+
+pub type SystemManagerType = Box<dyn SystemManager + Sync + Send>;
+
+pub trait SystemManager {
+    /// Collects information about the status of this machine
+    fn collect_stats(&self) -> Result<MachineStat>;
+
+    /// Collects information about the gpus on this machine
+    fn collect_gpu_stats(&self) -> MachineGpuStats;
+
+    /// Up, Down, Rebooting...
+    fn hardware_state(&self) -> &HardwareState;
+
+    /// List of attributes collected from the machine. Eg. SP_OS
+    fn attributes(&self) -> &HashMap<String, String>;
+
+    /// Init NotInMyBackyard logic
+    fn init_nimby(&self) -> Result<bool>;
+
+    /// Returns a map of cores per socket that are not reserved
+    fn cpu_stat(&self) -> CpuStat;
+
+    /// Reserver a number of cores.
+    ///
+    /// # Returns:
+    ///
+    /// * Vector of core ids
+    fn reserve_cores(&mut self, count: u32, frame_id: Uuid) -> Result<Vec<u32>, ReservationError>;
+
+    /// Reserver specific cores by id.
+    ///
+    /// # Returns:
+    ///
+    /// * Vector of core ids
+    fn reserve_cores_by_id(
+        &mut self,
+        cpu_list: &Vec<u32>,
+        resource_id: Uuid,
+    ) -> Result<Vec<u32>, ReservationError>;
+
+    /// Release a core
+    fn release_core(&mut self, core_id: &u32) -> Result<(), ReservationError>;
+
+    /// Creates an user if it doesn't already exist
+    fn create_user_if_unexisting(&self, username: &str, uid: u32, gid: u32) -> Result<u32>;
+
+    /// Collects stats of a process
+    fn collect_proc_stats(&self, pid: u32, log_path: String) -> Result<Option<ProcessStats>>;
+
+    /// Update info about procs currently active
+    fn refresh_procs(&self, pids: Vec<u32>);
+
+    /// Kill a pid
+    fn kill(&self, pid: u32) -> Result<()>;
+
+    /// Force kill a list of pids
+    fn force_kill(&self, pids: &Vec<u32>) -> Result<()>;
+
+    /// Returns the list of active children, and none if the pid itself is not active
+    fn get_proc_lineage(&self, pid: u32) -> Option<Vec<u32>>;
+}
+
+#[derive(Debug, Clone, Diagnostic, Error)]
+pub enum ReservationError {
+    #[error("No resources available to be reserved")]
+    NotEnoughResourcesAvailable,
+
+    #[error("Could not find resource with provided key: {0}")]
+    NotFoundError(u32),
+}
+
+#[derive(Debug, Clone)]
+pub struct CpuStat {
+    /// List of cores currently reserved
+    pub reserved_cores_by_physid: HashMap<u32, CoreReservation>,
+    pub available_cores: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoreReservation {
+    pub reserved_cores: HashSet<u32>,
+    pub reserver_id: Uuid,
+    pub start_time: Instant,
+}
+
+impl CoreReservation {
+    pub fn new(reserver_id: Uuid) -> Self {
+        CoreReservation {
+            reserved_cores: HashSet::new(),
+            reserver_id,
+            start_time: Instant::now(),
+        }
+    }
+
+    pub fn iter(&self) -> std::collections::hash_set::Iter<'_, u32> {
+        self.reserved_cores.iter()
+    }
+
+    pub fn insert(&mut self, core_id: u32) -> bool {
+        self.reserved_cores.insert(core_id)
+    }
+
+    pub fn remove(&mut self, core_id: &u32) -> bool {
+        self.reserved_cores.remove(core_id)
+    }
+}
+
+/// Represents attributes on a machine that should never change withour restarting the
+/// entire servive
+#[derive(Clone, Debug)]
+pub struct MachineStat {
+    /// Machine name
+    pub hostname: String,
+    /// Total number of processing units (also known as virtual cores)
+    pub num_procs: u32,
+    /// Total amount of memory on the machine
+    pub total_memory: u64,
+    /// Total amount of swap space on the machine
+    pub total_swap: u64,
+    /// Total number of physical cores (also known as sockets)
+    pub num_sockets: u32,
+    /// Number of cores per processor unit
+    pub cores_per_proc: u32,
+    /// Multiplier value for hyper-threading, does not apply to total_procs unlike in python version
+    pub hyperthreading_multiplier: u32,
+    /// Timestamp for when the machine was booted up
+    pub boot_time: u32,
+    /// List of tags associated with this machine
+    pub tags: Vec<String>,
+    /// Amount of available memory on the machine. For Linux/Macos Free + Cached
+    pub available_memory: u64,
+    /// Amount of free swap space on the machine
+    pub free_swap: u64,
+    /// Total temporary storage available on the machine
+    pub total_temp_storage: u64,
+    /// Amount of free temporary storage on the machine
+    pub free_temp_storage: u64,
+    /// Current load on the machine
+    pub load: u32,
+}
+
+pub struct MachineGpuStats {
+    /// Count of GPUs
+    pub count: u32,
+    /// Total memory of all GPUs
+    pub total_memory: u64,
+    /// Available free memory of all GPUs
+    pub free_memory: u64,
+    /// Used memory by unit of each GPU, where the key in the HashMap is the unit ID, and the value is the used memory
+    pub used_memory_by_unit: HashMap<u32, u64>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ProcessStats {
+    /// Maximum resident set size (KB) - maximum amount of physical memory used.
+    pub max_rss: u64,
+    /// Current resident set size (KB) - amount of physical memory currently in use.
+    pub rss: u64,
+    /// Maximum virtual memory size (KB) - maximum amount of virtual memory used.
+    pub max_vsize: u64,
+    /// Current virtual memory size (KB) - amount of virtual memory currently in use.
+    pub vsize: u64,
+    /// Last time the log was updated
+    pub llu_time: u64,
+    /// Maximum GPU memory usage (KB).
+    pub max_used_gpu_memory: u64,
+    /// Current GPU memory usage (KB).
+    pub used_gpu_memory: u64,
+    /// Additional data about the running frame's child processes.
+    pub children: Option<ChildrenProcStats>,
+    /// Unix timestamp denoting the start time of the frame process.
+    pub epoch_start_time: u64,
+}
+
+impl Default for ProcessStats {
+    fn default() -> Self {
+        ProcessStats {
+            max_rss: 0,
+            rss: 0,
+            max_vsize: 0,
+            vsize: 0,
+            llu_time: 0,
+            max_used_gpu_memory: 0,
+            used_gpu_memory: 0,
+            children: None,
+            epoch_start_time: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_else(|_| std::time::Duration::from_secs(0))
+                .as_secs(),
+        }
+    }
+}
+
+/// Get the max between two u64s
+fn max_u64(left: u64, right: u64) -> u64 {
+    (left > right).then(|| left).unwrap_or(right)
+}
+
+impl ProcessStats {
+    pub fn update(&mut self, new: Self) {
+        *self = ProcessStats {
+            max_rss: max_u64(new.max_rss, self.max_rss),
+            max_vsize: max_u64(new.max_vsize, self.max_vsize),
+            max_used_gpu_memory: max_u64(new.max_used_gpu_memory, self.max_used_gpu_memory),
+            ..new
+        };
+    }
+}

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -62,8 +62,11 @@ pub trait SystemManager {
     /// Update info about procs currently active
     fn refresh_procs(&self);
 
-    /// Kill a pid
-    fn kill(&self, pid: u32) -> Result<()>;
+    /// Kill a session using the session pid
+    fn kill_session(&self, session_pid: u32) -> Result<()>;
+
+    /// Force kill a session using the session pid
+    fn force_kill_session(&self, session_pid: u32) -> Result<()>;
 
     /// Force kill a list of pids
     fn force_kill(&self, pids: &Vec<u32>) -> Result<()>;

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -60,7 +60,7 @@ pub trait SystemManager {
     fn collect_proc_stats(&self, pid: u32, log_path: String) -> Result<Option<ProcessStats>>;
 
     /// Update info about procs currently active
-    fn refresh_procs(&self, pids: Vec<u32>);
+    fn refresh_procs(&self);
 
     /// Kill a pid
     fn kill(&self, pid: u32) -> Result<()>;

--- a/crates/rqd/src/system/mod.rs
+++ b/crates/rqd/src/system/mod.rs
@@ -1,2 +1,3 @@
 pub mod machine;
+pub mod manager;
 pub mod unix;

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -12,7 +12,7 @@ use std::{
 use dashmap::DashMap;
 use itertools::Itertools;
 use miette::{IntoDiagnostic, Result, miette};
-use nix::sys::signal::{Signal, kill};
+use nix::sys::signal::{Signal, kill, killpg};
 use opencue_proto::host::HardwareState;
 use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System,
@@ -861,7 +861,7 @@ impl SystemManager for UnixSystem {
     }
 
     fn kill(&self, pid: u32) -> Result<()> {
-        kill(nix::unistd::Pid::from_raw(pid as i32), Signal::SIGTERM)
+        killpg(nix::unistd::Pid::from_raw(pid as i32), Signal::SIGTERM)
             .map_err(|err| miette!("Failed to kill {pid}. {err}"))
     }
 

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -17,7 +17,7 @@ use opencue_proto::host::HardwareState;
 use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::config::config::MachineConfig;

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -17,7 +17,7 @@ use opencue_proto::host::HardwareState;
 use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System,
 };
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::config::config::MachineConfig;
@@ -40,7 +40,8 @@ pub struct UnixSystem {
     attributes: HashMap<String, String>,
     sysinfo_system: Mutex<sysinfo::System>,
     // Cache of all processes and their children
-    procs_children_cache: DashMap<u32, Vec<u32>>,
+    // This cache is only active if use_session_id_for_proc_lineage=true
+    procs_children_cache: Option<DashMap<u32, Vec<u32>>>,
     // Cache of monitored processes and their lineage
     procs_lineage_cache: DashMap<u32, Vec<u32>>,
 }
@@ -137,7 +138,10 @@ impl UnixSystem {
                 available_cores: available_core_count,
             },
             sysinfo_system: Mutex::new(sysinfo::System::new()),
-            procs_children_cache: DashMap::new(),
+            procs_children_cache: match config.use_session_id_for_proc_lineage {
+                true => None,
+                false => Some(DashMap::new()),
+            },
             procs_lineage_cache: DashMap::new(),
         })
     }
@@ -543,30 +547,80 @@ impl UnixSystem {
             .sysinfo_system
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        // Clear up cache
-        self.procs_children_cache.clear();
+        if self.config.use_session_id_for_proc_lineage {
+            // Group all processes by session_id
+            for (session_pid, pid) in sysinfo.processes().iter().map(|(children_pid, proc)| {
+                let session_pid = proc.session_id().unwrap_or(Pid::from_u32(0)).as_u32();
+                (session_pid, children_pid.clone().as_u32())
+            }) {
+                self.procs_lineage_cache
+                    .entry(session_pid)
+                    .and_modify(|procs| procs.push(pid))
+                    .or_insert(vec![pid]);
+            }
+        } else {
+            let procs_children_cache = self.procs_children_cache.as_ref().expect(
+                "Invalid State. \
+                    procs_children_cache should be some if use_session_id_for_proc_lineage is true",
+            );
+            procs_children_cache.clear();
 
-        // Collect all procs and its direct children
-        for (parent_pid, children_pid) in sysinfo.processes().iter().map(|(children_pid, proc)| {
-            let parent_pid = proc.parent().unwrap_or(Pid::from_u32(0)).as_u32();
-            (parent_pid, children_pid.clone())
-        }) {
-            self.procs_children_cache
-                .entry(parent_pid)
-                .and_modify(|children| children.push(children_pid.as_u32()))
-                .or_insert(vec![children_pid.as_u32()]);
+            // Collect all procs and its direct children
+            for (parent_pid, pid) in sysinfo.processes().iter().map(|(children_pid, proc)| {
+                let parent_pid = proc.parent().unwrap_or(Pid::from_u32(0)).as_u32();
+                (parent_pid, children_pid.clone().as_u32())
+            }) {
+                procs_children_cache
+                    .entry(parent_pid)
+                    .and_modify(|children| children.push(pid))
+                    .or_insert(vec![pid]);
+            }
+            // Clear up procs that have finished (disapeared from procs_children_cache)
+            let procs_to_clear: Vec<u32> = self
+                .procs_lineage_cache
+                .iter()
+                .filter(|item| !procs_children_cache.contains_key(item.key()))
+                .map(|item| item.key().clone())
+                .collect();
+            for pid in procs_to_clear {
+                self.procs_lineage_cache.remove(&pid);
+            }
         }
+    }
 
-        // Clear procs that have finished from lineage cache
-        let procs_to_clear: Vec<u32> = self
-            .procs_lineage_cache
-            .iter()
-            .filter(|item| !self.procs_children_cache.contains_key(item.key()))
-            .map(|item| item.key().clone())
-            .collect();
-        for pid in procs_to_clear {
-            self.procs_lineage_cache.remove(&pid);
-        }
+    /// Calculates memory usage of all processes associated with a session ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The session ID to calculate memory for
+    /// * `sysinfo` - A mutex guard containing system information
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    /// * Memory usage in bytes
+    /// * Virtual memory usage in bytes
+    /// * GPU memory usage in bytes (currently always 0)
+    /// * The updated mutex guard reference
+    fn calculate_session_memory<'a>(
+        &self,
+        session_id: &u32,
+        sysinfo: MutexGuard<'a, System>,
+    ) -> (u64, u64, u64, MutexGuard<'a, System>) {
+        let (memory, virtual_memory, gpu_memory) = match self.procs_lineage_cache.get(session_id) {
+            Some(ref lineage) => lineage
+                .iter()
+                .map(
+                    |pid| match sysinfo.process(Pid::from(pid.clone() as usize)) {
+                        Some(proc) => (proc.memory(), proc.virtual_memory(), 0),
+                        None => (0, 0, 0),
+                    },
+                )
+                .reduce(|a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2))
+                .unwrap_or((0, 0, 0)),
+            None => (0, 0, 0),
+        };
+        (memory, virtual_memory, gpu_memory, sysinfo)
     }
 
     /// Recursively calculates memory usage of a process and all of its child processes.
@@ -590,54 +644,64 @@ impl UnixSystem {
     ///
     /// This function recursively traverses the process tree to sum up memory usage.
     /// It uses cycle detection to prevent infinite loops in process hierarchies.
-    fn calculate_children_memory<'a>(
+    ///
+    /// GPU memory calculation is still pending
+    fn calculate_children_memory_traverse_lineage<'a>(
         &'a self,
         pid: &u32,
         mut sysinfo: MutexGuard<'a, System>,
         mut cycle_trace: Vec<u32>,
     ) -> (u64, u64, u64, MutexGuard<'a, System>, Vec<u32>) {
-        match sysinfo.process(Pid::from(pid.clone() as usize)) {
-            Some(proc) => match self.procs_children_cache.get(pid) {
-                Some(children_pids) => {
-                    cycle_trace.push(pid.clone());
-                    let (mut sum_memory, mut sum_virtual_memory, mut sum_gpu_memory) =
-                        (proc.memory(), proc.virtual_memory(), 0);
-                    for child_pid in children_pids.iter() {
-                        // Check for cycles to avoid an infinite loop
-                        if cycle_trace.contains(child_pid) {
-                            warn!(
-                                "calculate_children_memory recursion found a loop.\
+        if let Some(procs_children_cache) = &self.procs_children_cache {
+            match sysinfo.process(Pid::from(pid.clone() as usize)) {
+                Some(proc) => match procs_children_cache.get(pid) {
+                    Some(children_pids) => {
+                        cycle_trace.push(pid.clone());
+                        let (mut sum_memory, mut sum_virtual_memory, mut sum_gpu_memory) =
+                            (proc.memory(), proc.virtual_memory(), 0);
+                        for child_pid in children_pids.iter() {
+                            // Check for cycles to avoid an infinite loop
+                            if cycle_trace.contains(child_pid) {
+                                warn!(
+                                    "calculate_children_memory recursion found a loop.\
                                 Incomplete memory calculation for {pid}."
+                                );
+                                break;
+                            }
+                            let (
+                                child_memory,
+                                child_virtual_memory,
+                                child_gpu_memory,
+                                updated_sysinfo,
+                                updated_cycle_trace,
+                            ) = self.calculate_children_memory_traverse_lineage(
+                                child_pid,
+                                sysinfo,
+                                cycle_trace,
                             );
-                            break;
+                            sum_memory += child_memory;
+                            sum_virtual_memory += child_virtual_memory;
+                            sum_gpu_memory += child_gpu_memory;
+                            // Update our reference to the mutex guard and cycle_trace
+                            sysinfo = updated_sysinfo;
+                            cycle_trace = updated_cycle_trace;
                         }
-                        let (
-                            child_memory,
-                            child_virtual_memory,
-                            child_gpu_memory,
-                            updated_sysinfo,
-                            updated_cycle_trace,
-                        ) = self.calculate_children_memory(child_pid, sysinfo, cycle_trace);
-                        sum_memory += child_memory;
-                        sum_virtual_memory += child_virtual_memory;
-                        sum_gpu_memory += child_gpu_memory;
-                        // Update our reference to the mutex guard and cycle_trace
-                        sysinfo = updated_sysinfo;
-                        cycle_trace = updated_cycle_trace;
+                        (
+                            sum_memory,
+                            sum_virtual_memory,
+                            sum_gpu_memory,
+                            sysinfo,
+                            cycle_trace,
+                        )
                     }
-                    (
-                        sum_memory,
-                        sum_virtual_memory,
-                        sum_gpu_memory,
-                        sysinfo,
-                        cycle_trace,
-                    )
-                }
-                // Process has no children
-                None => (proc.memory(), proc.virtual_memory(), 0, sysinfo, Vec::new()),
-            },
-            // Process no longer exists
-            None => (0, 0, 0, sysinfo, Vec::new()),
+                    // Process has no children
+                    None => (proc.memory(), proc.virtual_memory(), 0, sysinfo, Vec::new()),
+                },
+                // Process no longer exists
+                None => (0, 0, 0, sysinfo, Vec::new()),
+            }
+        } else {
+            (0, 0, 0, sysinfo, Vec::new())
         }
     }
 }
@@ -814,40 +878,67 @@ impl SystemManager for UnixSystem {
             .unwrap_or_default()
             .as_secs();
 
-        // Summation of all children memory consumption
         let sysinfo = self
             .sysinfo_system
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        let (summed_memory, summed_virtual_memory, summed_gpu_memory, guard, lineage) =
-            self.calculate_children_memory(&pid, sysinfo, Vec::new());
-        debug!(
-            "Collect frame stats fo {}. rss: {}mb virtual: {}mb gpu: {}mb",
-            pid,
-            summed_memory / 1024 / 1024,
-            summed_virtual_memory / 1024 / 1024,
-            summed_gpu_memory / 1024 / 1024
-        );
+        if self.config.use_session_id_for_proc_lineage {
+            let (summed_memory, summed_virtual_memory, summed_gpu_memory, guard) =
+                self.calculate_session_memory(&pid, sysinfo);
 
-        self.procs_lineage_cache.insert(pid, lineage);
+            debug!(
+                "Collect frame stats fo {}. rss: {}mb virtual: {}mb gpu: {}mb",
+                pid,
+                summed_memory / 1024 / 1024,
+                summed_virtual_memory / 1024 / 1024,
+                summed_gpu_memory / 1024 / 1024
+            );
+            Ok(guard
+                .process(Pid::from(pid as usize))
+                .map(|proc| ProcessStats {
+                    // Caller is responsible for maintaining the Max value between calls
+                    max_rss: summed_memory,
+                    rss: summed_memory,
+                    max_vsize: summed_virtual_memory,
+                    vsize: summed_virtual_memory,
+                    llu_time: log_mtime,
+                    max_used_gpu_memory: 0,
+                    used_gpu_memory: summed_gpu_memory,
+                    children: None,
+                    epoch_start_time: proc.start_time(),
+                }))
+        } else {
+            // Traverse the tree of procs using their parent id and calculate memory consumption
+            let (summed_memory, summed_virtual_memory, summed_gpu_memory, guard, lineage) =
+                self.calculate_children_memory_traverse_lineage(&pid, sysinfo, Vec::new());
 
-        Ok(guard
-            .process(Pid::from(pid as usize))
-            .map(|proc| ProcessStats {
-                // Caller is responsible for maintaining the Max value between calls
-                max_rss: summed_memory,
-                rss: summed_memory,
-                max_vsize: summed_virtual_memory,
-                vsize: summed_virtual_memory,
-                llu_time: log_mtime,
-                max_used_gpu_memory: 0,
-                used_gpu_memory: summed_gpu_memory,
-                children: None,
-                epoch_start_time: proc.start_time(),
-            }))
+            debug!(
+                "Collect frame stats fo {}. rss: {}mb virtual: {}mb gpu: {}mb",
+                pid,
+                summed_memory / 1024 / 1024,
+                summed_virtual_memory / 1024 / 1024,
+                summed_gpu_memory / 1024 / 1024
+            );
+
+            self.procs_lineage_cache.insert(pid, lineage);
+            Ok(guard
+                .process(Pid::from(pid as usize))
+                .map(|proc| ProcessStats {
+                    // Caller is responsible for maintaining the Max value between calls
+                    max_rss: summed_memory,
+                    rss: summed_memory,
+                    max_vsize: summed_virtual_memory,
+                    vsize: summed_virtual_memory,
+                    llu_time: log_mtime,
+                    max_used_gpu_memory: 0,
+                    used_gpu_memory: summed_gpu_memory,
+                    children: None,
+                    epoch_start_time: proc.start_time(),
+                }))
+        }
     }
 
-    fn refresh_procs(&self, pids: Vec<u32>) {
+    fn refresh_procs(&self) {
         let mut sysinfo = self
             .sysinfo_system
             .lock()
@@ -885,6 +976,8 @@ impl SystemManager for UnixSystem {
             .get(&pid)
             .map(|lineage| lineage.clone())
     }
+
+    // fn get_procs_by_pgid(&self, pgid: u32) -> Option<Vec<u32>> {}
 }
 
 #[cfg(test)]
@@ -1245,7 +1338,7 @@ mod tests {
                 hardware_state: HardwareState::Up,
                 attributes: HashMap::new(),
                 sysinfo_system: Mutex::new(sysinfo::System::new()),
-                procs_children_cache: DashMap::new(),
+                procs_children_cache: Some(DashMap::new()),
                 procs_lineage_cache: DashMap::new(),
             }
         }


### PR DESCRIPTION
Logic sends a SIGTERM to the running frame and monitor the its pid and spawn children (lineage) to ensure everything was killed. If `config.runner.force_kill_after_timeout=true`, after `config.runner.kill_monitor_timeout` is reached, send a SIGKILL to the pid and all its lineage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced frame management with commands to terminate frames and monitor their status.
  - Added support for killing running frames with optional reasons via client commands.
  - Introduced new configuration options for monitoring intervals, process lineage, and kill timeouts.
  - Added new shell scripts to assist with command execution and signal handling.
  - Extended system resource management with process killing and lineage retrieval capabilities.

- **Refactor**
  - Updated configuration to use human-readable duration formats and improved error messages.
  - Simplified process lineage caching and memory calculation logic with session-based grouping.
  - Consolidated system management interfaces, removing legacy abstractions for clarity.
  - Streamlined frame command building with enhanced script generation and signal handling.
  - Improved running frame state management and thread handle ownership.

- **Chore**
  - Added new dependencies for time serialization and formatting.
  - Removed unused imports and obsolete traits for cleaner codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->