### PR TITLE
Write footer

### DIFF
--- a/crates/rqd/resources/test_scripts/memory_fork.sh
+++ b/crates/rqd/resources/test_scripts/memory_fork.sh
@@ -42,8 +42,8 @@ allocate_memory &
 child2_pid=$!
 echo "Second child process has PID: $child2_pid"
 
-echo "All processes running. Parent will wait for 5 minutes before exiting."
-sleep 120
+echo "All processes running. Parent will wait before exiting."
+sleep 60
 
 # Clean up child processes
 kill $child1_pid $child2_pid 2>/dev/null

--- a/crates/rqd/src/frame/cache.rs
+++ b/crates/rqd/src/frame/cache.rs
@@ -37,7 +37,7 @@ impl RunningFrameCache {
             .map(|running_frame| {
                 let frame_stats = running_frame
                     .frame_stats
-                    .lock()
+                    .read()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .clone()
                     .unwrap_or_default();

--- a/crates/rqd/src/frame/manager.rs
+++ b/crates/rqd/src/frame/manager.rs
@@ -301,7 +301,7 @@ impl FrameManager {
     pub async fn kill_running_frame(&self, frame_id: &Uuid, reason: String) -> Result<Option<()>> {
         match self.get_running_frame(frame_id) {
             Some(running_frame) => {
-                let pid = running_frame.get_pid_to_kill();
+                let pid = running_frame.get_pid_to_kill(&reason);
                 if let Ok(frame_pid) = pid {
                     info!(
                         "Killing frame {running_frame}({frame_pid}) by request.\n\

--- a/crates/rqd/src/frame/running_frame.rs
+++ b/crates/rqd/src/frame/running_frame.rs
@@ -340,7 +340,7 @@ impl RunningFrame {
                     if let Err(err) = self.finish(exit_code, exit_signal) {
                         warn!("Failed to mark frame {} as finished. {}", self, err);
                     }
-                    self.write_footer();
+                    logger.writeln(&self.write_footer());
                     Some(exit_code)
                 }
                 Err(err) => {
@@ -356,7 +356,7 @@ impl RunningFrame {
                     if let Err(err) = self.finish(exit_code, exit_signal) {
                         warn!("Failed to mark frame {} as finished. {}", self, err);
                     }
-                    self.write_footer();
+                    logger.writeln(&self.write_footer());
                     Some(exit_code)
                 }
                 Err(err) => {
@@ -1004,8 +1004,8 @@ ________________________________________________________________________________
     child_pid           {}
     cmdline             {}
     maxrss              {}
-                        "#,
-                                    child_stat.pid, child.cmdline, child_stat.rss
+    start_time          {}"#,
+                                    child_stat.pid, child.cmdline, child_stat.rss, child.start_time
                                 )
                             })
                             .join("\n")
@@ -1024,8 +1024,7 @@ maxrss              {maxrss}
 maxUsedGpuMemory    {max_gpu_memory}
 runTime             {run_time}
 
-Processes:
-{children}
+Processes:{children}
 ===================================================================================================="#
                 )
             }

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -193,7 +193,7 @@ impl MachineMonitor {
                         None
                     })
                 {
-                    if let Ok(mut frame_stats) = running_frame.frame_stats.lock() {
+                    if let Ok(mut frame_stats) = running_frame.frame_stats.write() {
                         if let Some(old_frame_stats) = frame_stats.as_mut() {
                             old_frame_stats.update(proc_stats);
                         } else {

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -185,6 +185,8 @@ pub struct ProcessStats {
     pub children: Option<ChildrenProcStats>,
     /// Unix timestamp denoting the start time of the frame process.
     pub epoch_start_time: u64,
+    /// Total runtime of the longer lasting process in the lineage
+    pub run_time: u64,
 }
 
 impl Default for ProcessStats {
@@ -202,21 +204,18 @@ impl Default for ProcessStats {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_else(|_| std::time::Duration::from_secs(0))
                 .as_secs(),
+            run_time: 0,
         }
     }
-}
-
-/// Get the max between two u64s
-fn max_u64(left: u64, right: u64) -> u64 {
-    (left > right).then(|| left).unwrap_or(right)
 }
 
 impl ProcessStats {
     pub fn update(&mut self, new: Self) {
         *self = ProcessStats {
-            max_rss: max_u64(new.max_rss, self.max_rss),
-            max_vsize: max_u64(new.max_vsize, self.max_vsize),
-            max_used_gpu_memory: max_u64(new.max_used_gpu_memory, self.max_used_gpu_memory),
+            max_rss: std::cmp::max(new.max_rss, self.max_rss),
+            max_vsize: std::cmp::max(new.max_vsize, self.max_vsize),
+            max_used_gpu_memory: std::cmp::max(new.max_used_gpu_memory, self.max_used_gpu_memory),
+            run_time: std::cmp::max(new.run_time, self.run_time),
             ..new
         };
     }

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -6,14 +6,18 @@ use std::{
     path::Path,
     process::Command,
     sync::{Mutex, MutexGuard},
-    time::UNIX_EPOCH,
+    time::{Duration, UNIX_EPOCH},
 };
 
+use chrono::{DateTime, Local};
 use dashmap::DashMap;
 use itertools::Itertools;
 use miette::{IntoDiagnostic, Result, miette};
 use nix::sys::signal::{Signal, kill, killpg};
-use opencue_proto::host::HardwareState;
+use opencue_proto::{
+    host::HardwareState,
+    report::{ChildrenProcStats, ProcStats, Stat},
+};
 use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System,
 };
@@ -603,29 +607,57 @@ impl UnixSystem {
     /// * Virtual memory usage in bytes
     /// * GPU memory usage in bytes (currently always 0)
     /// * Proc runtime in seconds
+    /// * Vec of stats for all procs on the lineage
     /// * The updated mutex guard reference
     fn calculate_session_memory<'a>(
         &self,
         session_id: &u32,
         sysinfo: MutexGuard<'a, System>,
-    ) -> (u64, u64, u64, u64, MutexGuard<'a, System>) {
-        let (memory, virtual_memory, gpu_memory, run_time) = match self
-            .procs_lineage_cache
-            .get(session_id)
-        {
-            Some(ref lineage) => lineage
-                .iter()
-                .map(
-                    |pid| match sysinfo.process(Pid::from(pid.clone() as usize)) {
-                        Some(proc) => (proc.memory(), proc.virtual_memory(), proc.run_time(), 0),
-                        None => (0, 0, 0, 0),
-                    },
-                )
-                .reduce(|a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2, std::cmp::max(a.3, b.3)))
-                .unwrap_or((0, 0, 0, 0)),
-            None => (0, 0, 0, 0),
-        };
-        (memory, virtual_memory, gpu_memory, run_time, sysinfo)
+    ) -> (u64, u64, u64, u64, Vec<ProcStats>, MutexGuard<'a, System>) {
+        let mut children = Vec::new();
+        let (memory, virtual_memory, gpu_memory, run_time) =
+            match self.procs_lineage_cache.get(session_id) {
+                Some(ref lineage) => lineage
+                    .iter()
+                    .map(
+                        |pid| match sysinfo.process(Pid::from(pid.clone() as usize)) {
+                            Some(proc) => {
+                                let start_time_str = DateTime::<Local>::from(
+                                    UNIX_EPOCH + Duration::from_secs(proc.start_time()),
+                                )
+                                .format("%Y-%m-%d %H:%M:%S")
+                                .to_string();
+                                children.push(ProcStats {
+                                    stat: Some(Stat {
+                                        rss: proc.memory() as i64,
+                                        vsize: proc.virtual_memory() as i64,
+                                        state: "".to_string(),
+                                        name: proc.name().to_string_lossy().to_string(),
+                                        pid: pid.to_string(),
+                                    }),
+                                    statm: None,
+                                    status: None,
+                                    // TODO: cmd() doesn't seem to return argv. Find a better option
+                                    cmdline: format!("{:?}", proc.cmd()),
+                                    start_time: start_time_str,
+                                });
+                                (proc.memory(), proc.virtual_memory(), 0, proc.run_time())
+                            }
+                            None => (0, 0, 0, 0),
+                        },
+                    )
+                    .reduce(|a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2, std::cmp::max(a.3, b.3)))
+                    .unwrap_or((0, 0, 0, 0)),
+                None => (0, 0, 0, 0),
+            };
+        (
+            memory,
+            virtual_memory,
+            gpu_memory,
+            run_time,
+            children,
+            sysinfo,
+        )
     }
 
     /// Recursively calculates memory usage of a process and all of its child processes.
@@ -902,8 +934,14 @@ impl SystemManager for UnixSystem {
             .lock()
             .unwrap_or_else(|err| err.into_inner());
         if self.config.use_session_id_for_proc_lineage {
-            let (summed_memory, summed_virtual_memory, summed_gpu_memory, total_run_time, guard) =
-                self.calculate_session_memory(&pid, sysinfo);
+            let (
+                summed_memory,
+                summed_virtual_memory,
+                summed_gpu_memory,
+                total_run_time,
+                children,
+                guard,
+            ) = self.calculate_session_memory(&pid, sysinfo);
 
             debug!(
                 "Collect frame stats fo {}. rss: {}mb virtual: {}mb gpu: {}mb",
@@ -923,7 +961,7 @@ impl SystemManager for UnixSystem {
                     llu_time: log_mtime,
                     max_used_gpu_memory: 0,
                     used_gpu_memory: summed_gpu_memory,
-                    children: None,
+                    children: Some(ChildrenProcStats { children }),
                     epoch_start_time: proc.start_time(),
                     run_time: total_run_time,
                 }))


### PR DESCRIPTION
Add frame footer to the end of rqd logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking and reporting of the reason when a running frame is killed.
  - Enhanced process statistics to include total runtime and detailed per-process stats, including child processes.
  - Improved logging with a detailed summary footer after frame completion, showing exit status, kill reason, timing, and resource usage.

- **Improvements**
  - Optimized concurrency for frame statistics to allow more efficient data access.
  - Updated memory and runtime monitoring for more accurate and comprehensive reporting.

- **Other Changes**
  - Adjusted script timing in test scripts for faster execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->