### PR TITLE
Add missing rqd servant functionality

### DIFF
--- a/crates/opencue-proto/src/lib.rs
+++ b/crates/opencue-proto/src/lib.rs
@@ -113,7 +113,7 @@ impl CoreDetail {
     ///
     /// # Arguments
     ///
-    /// * `core_count_with_multiplier` - The number of cores to reserve
+    /// * `core_count_with_multiplier` - Number of cores to reserve multiplied by core_multiplier
     ///
     /// # Returns
     ///
@@ -136,7 +136,7 @@ impl CoreDetail {
     ///
     /// # Arguments
     ///
-    /// * `core_count_with_multiplier` - The number of cores to release
+    /// * `core_count_with_multiplier` - The number of cores to release multiplied by core_multiplier
     ///
     /// # Returns
     ///
@@ -152,6 +152,65 @@ impl CoreDetail {
             self.idle_cores += core_count_with_multiplier as i32;
             self.booked_cores -= core_count_with_multiplier as i32;
             Ok(())
+        }
+    }
+
+    /// Update CoreDetail by locking a specified number of cores. If the amount requested is
+    /// not available, the maximum available will be reserved.
+    ///
+    /// # Arguments
+    ///
+    /// * `count_with_multiplier` - Number of cores to lock multiplied by core_multiplier
+    ///
+    /// # Returns
+    ///
+    /// * `u32` - The actual number of cores that were locked (may be less than requested if not enough are available)
+    pub fn lock_cores(&mut self, count_with_multiplier: u32) -> u32 {
+        let amount_not_locked = self.total_cores - self.locked_cores;
+        let amount_to_lock = std::cmp::min(amount_not_locked, count_with_multiplier as i32);
+
+        if amount_to_lock > 0 {
+            self.locked_cores += amount_to_lock;
+            self.idle_cores -= std::cmp::min(amount_to_lock, self.idle_cores)
+        }
+
+        amount_to_lock as u32
+    }
+
+    /// Update CoreDetail by locking all available cores
+    ///
+    /// This will set idle_cores to 0 and locked_cores to total_cores
+    pub fn lock_all_cores(&mut self) {
+        self.idle_cores = 0;
+        self.locked_cores = self.total_cores;
+    }
+
+    /// Update CoreDetail by unlocking a specified number of cores that were previously locked.
+    ///
+    /// # Arguments
+    ///
+    /// * `count_with_multiplier` - Number of cores to unlock multiplied by core_multiplier
+    ///
+    /// # Returns
+    ///
+    /// * `u32` - The actual number of cores that were unlocked (may be less than requested if fewer cores are locked)
+    pub fn unlock_cores(&mut self, count_with_multiplier: u32) -> u32 {
+        let amount_to_unlock = std::cmp::min(count_with_multiplier as i32, self.locked_cores);
+
+        if amount_to_unlock > 0 {
+            self.locked_cores -= amount_to_unlock;
+            self.idle_cores += amount_to_unlock;
+        }
+        amount_to_unlock as u32
+    }
+
+    /// Update CoreDetail by unlocking all locked cores
+    ///
+    /// This will unlock all locked cores and add them to idle_cores
+    pub fn unlock_all_cores(&mut self) {
+        if self.locked_cores > 0 {
+            self.idle_cores += self.locked_cores;
+            self.locked_cores = 0;
         }
     }
 }

--- a/crates/opencue-proto/src/protos/rqd.proto
+++ b/crates/opencue-proto/src/protos/rqd.proto
@@ -41,7 +41,7 @@ service RqdInterface {
     // Reboot the host when it becomes idle
     rpc RebootIdle(RqdStaticRebootIdleRequest) returns (RqdStaticRebootIdleResponse);
 
-    // Reboot the host now
+    // [Deprecated] Reboot the host now
     rpc RebootNow(RqdStaticRebootNowRequest) returns (RqdStaticRebootNowResponse);
 
     // Return the HostReport
@@ -53,7 +53,7 @@ service RqdInterface {
     // [Deprecated] Restart rqd process now
     rpc RestartRqdNow(RqdStaticRestartNowRequest) returns (RqdStaticRestartNowResponse);
 
-    // Turn off rqd when it becomes idle
+    // [Deprecated] Turn off rqd when it becomes idle
     rpc ShutdownRqdIdle(RqdStaticShutdownIdleRequest) returns (RqdStaticShutdownIdleResponse);
 
     // Stop rqd now

--- a/crates/rqd/Cargo.toml
+++ b/crates/rqd/Cargo.toml
@@ -41,7 +41,7 @@ deadpool-postgres = "0.14.0"
 tonic = { workspace = true }
 itertools = "0.13.0"
 sysinfo = "0.33.1"
-nix = { version = "0.29", features = ["process", "signal"] }
+nix = { version = "0.29", features = ["process", "signal", "reboot"] }
 users = "0.11"
 humantime = "2.2.0"
 humantime-serde = "1.1.1"

--- a/crates/rqd/src/report/report_client.rs
+++ b/crates/rqd/src/report/report_client.rs
@@ -151,12 +151,7 @@ pub trait ReportInterface {
         exit_signal: u32,
         run_time: u32,
     ) -> Result<()>;
-    async fn send_host_report(
-        &self,
-        host: pb::RenderHost,
-        frames: Vec<pb::RunningFrameInfo>,
-        core_info: pb::CoreDetail,
-    ) -> Result<()>;
+    async fn send_host_report(&self, host_report: pb::HostReport) -> Result<()>;
 }
 
 #[async_trait]
@@ -203,18 +198,9 @@ impl ReportInterface for ReportClient {
             .and(Ok(()))
     }
 
-    async fn send_host_report(
-        &self,
-        render_host: pb::RenderHost,
-        running_frames: Vec<pb::RunningFrameInfo>,
-        core_detail: pb::CoreDetail,
-    ) -> Result<()> {
+    async fn send_host_report(&self, host_report: pb::HostReport) -> Result<()> {
         let mut request = pb::RqdReportStatusRequest::default();
-        request.host_report = Some(pb::HostReport {
-            host: Some(render_host),
-            frames: running_frames,
-            core_info: Some(core_detail),
-        });
+        request.host_report = Some(host_report);
         self.get_client()
             .await?
             .report_status(request)

--- a/crates/rqd/src/servant/rqd_servant.rs
+++ b/crates/rqd/src/servant/rqd_servant.rs
@@ -23,6 +23,7 @@ use opencue_proto::{
     },
 };
 use tonic::{Request, Response, async_trait};
+use tracing::info;
 
 pub type MachineImpl = dyn Machine + Sync + Send;
 
@@ -130,15 +131,24 @@ impl RqdInterface for RqdServant {
         &self,
         request: Request<RqdStaticLockRequest>,
     ) -> Result<Response<RqdStaticLockResponse>> {
-        todo!()
+        let cores_to_lock = request.into_inner().cores;
+        let effectively_locked_amount = self.machine.lock_cores(cores_to_lock as u32).await;
+        info!("Lock: {effectively_locked_amount} cores locked from the requeted {cores_to_lock}");
+
+        Ok(Response::new(RqdStaticLockResponse {}))
     }
+
     /// Lock all
     async fn lock_all(
         &self,
-        request: Request<RqdStaticLockAllRequest>,
+        _request: Request<RqdStaticLockAllRequest>,
     ) -> Result<Response<RqdStaticLockAllResponse>> {
-        todo!()
+        self.machine.lock_all_cores().await;
+        info!("Lock: All cores have been locked");
+
+        Ok(Response::new(RqdStaticLockAllResponse {}))
     }
+
     /// Disable NIMBY on host
     async fn nimby_off(
         &self,
@@ -146,6 +156,7 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticNimbyOffResponse>> {
         todo!()
     }
+
     /// Enable NIMBY on host
     async fn nimby_on(
         &self,
@@ -153,6 +164,7 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticNimbyOnResponse>> {
         todo!()
     }
+
     /// Reboot the host when it becomes idle
     async fn reboot_idle(
         &self,
@@ -160,6 +172,7 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticRebootIdleResponse>> {
         todo!()
     }
+
     /// Reboot the host now
     async fn reboot_now(
         &self,
@@ -167,6 +180,7 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticRebootNowResponse>> {
         todo!()
     }
+
     /// Return the HostReport
     async fn report_status(
         &self,
@@ -174,6 +188,7 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticReportStatusResponse>> {
         todo!()
     }
+
     /// [Deprecated] Restart the rqd process when it becomes idle
     async fn restart_rqd_idle(
         &self,
@@ -181,6 +196,7 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticRestartIdleResponse>> {
         todo!()
     }
+
     /// [Deprecated] Restart rqd process now
     async fn restart_rqd_now(
         &self,
@@ -203,18 +219,29 @@ impl RqdInterface for RqdServant {
     ) -> Result<Response<RqdStaticShutdownNowResponse>> {
         todo!()
     }
+
     /// Unlock a number of cores
     async fn unlock(
         &self,
         request: Request<RqdStaticUnlockRequest>,
     ) -> Result<Response<RqdStaticUnlockResponse>> {
-        todo!()
+        let cores_to_unlock = request.into_inner().cores;
+        let effectively_locked_amount = self.machine.unlock_cores(cores_to_unlock as u32).await;
+        info!(
+            "Unlock: {effectively_locked_amount} cores unlocked from the requeted {cores_to_unlock}"
+        );
+
+        Ok(Response::new(RqdStaticUnlockResponse {}))
     }
+
     /// Unlock all cores
     async fn unlock_all(
         &self,
-        request: Request<RqdStaticUnlockAllRequest>,
+        _request: Request<RqdStaticUnlockAllRequest>,
     ) -> Result<Response<RqdStaticUnlockAllResponse>> {
-        todo!()
+        self.machine.unlock_all_cores().await;
+        info!("Unlock: All cores have been unlocked");
+
+        Ok(Response::new(RqdStaticUnlockAllResponse {}))
     }
 }

--- a/crates/rqd/src/servant/rqd_servant.rs
+++ b/crates/rqd/src/servant/rqd_servant.rs
@@ -50,7 +50,7 @@ impl RqdServant {
 
 #[async_trait]
 impl RqdInterface for RqdServant {
-    /// Return the RunFrame by id
+    /// [Deprecated] Return the RunFrame by id
     async fn get_run_frame(
         &self,
         request: Request<RqdStaticGetRunFrameRequest>,
@@ -168,17 +168,26 @@ impl RqdInterface for RqdServant {
     /// Reboot the host when it becomes idle
     async fn reboot_idle(
         &self,
-        request: Request<RqdStaticRebootIdleRequest>,
+        _request: Request<RqdStaticRebootIdleRequest>,
     ) -> Result<Response<RqdStaticRebootIdleResponse>> {
-        todo!()
+        if let Err(err) = self.machine.reboot_if_idle().await {
+            Err(tonic::Status::aborted(format!(
+                "Failed to request reboot. {}",
+                err
+            )))?;
+        }
+        Ok(Response::new(RqdStaticRebootIdleResponse {}))
     }
 
-    /// Reboot the host now
+    /// [Deprecated] Reboot the host now
     async fn reboot_now(
         &self,
         request: Request<RqdStaticRebootNowRequest>,
     ) -> Result<Response<RqdStaticRebootNowResponse>> {
-        todo!()
+        todo!(
+            "Deprecated method not implemented by this interface {:?}",
+            request
+        )
     }
 
     /// Return the HostReport
@@ -194,7 +203,10 @@ impl RqdInterface for RqdServant {
         &self,
         request: Request<RqdStaticRestartIdleRequest>,
     ) -> Result<Response<RqdStaticRestartIdleResponse>> {
-        todo!()
+        todo!(
+            "Deprecated method not implemented by this interface {:?}",
+            request
+        )
     }
 
     /// [Deprecated] Restart rqd process now
@@ -202,15 +214,21 @@ impl RqdInterface for RqdServant {
         &self,
         request: Request<RqdStaticRestartNowRequest>,
     ) -> Result<Response<RqdStaticRestartNowResponse>> {
-        let _ = request;
-        todo!()
+        todo!(
+            "Deprecated method not implemented by this interface {:?}",
+            request
+        )
     }
-    /// Turn off rqd when it becomes idle
+
+    /// [Deprecated] Turn off rqd when it becomes idle
     async fn shutdown_rqd_idle(
         &self,
         request: Request<RqdStaticShutdownIdleRequest>,
     ) -> Result<Response<RqdStaticShutdownIdleResponse>> {
-        todo!()
+        todo!(
+            "Deprecated method not implemented by this interface {:?}",
+            request
+        )
     }
     /// Stop rqd now
     async fn shutdown_rqd_now(

--- a/crates/rqd/src/servant/rqd_servant.rs
+++ b/crates/rqd/src/servant/rqd_servant.rs
@@ -193,9 +193,19 @@ impl RqdInterface for RqdServant {
     /// Return the HostReport
     async fn report_status(
         &self,
-        request: Request<RqdStaticReportStatusRequest>,
+        _request: Request<RqdStaticReportStatusRequest>,
     ) -> Result<Response<RqdStaticReportStatusResponse>> {
-        todo!()
+        let host_report = self.machine.collect_host_report().await;
+
+        match host_report {
+            Ok(report) => Ok(Response::new(RqdStaticReportStatusResponse {
+                host_report: Some(report),
+            })),
+            Err(err) => Err(tonic::Status::internal(format!(
+                "Failed to collect host report {:?}",
+                err
+            ))),
+        }
     }
 
     /// [Deprecated] Restart the rqd process when it becomes idle

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -167,7 +167,9 @@ impl MachineMonitor {
     async fn check_reboot_flag(&self) {
         if *self.reboot_when_idle.lock().await {
             warn!("Machine became idle. Rebooting..");
-            self.system_manager.lock().await.reboot();
+            if let Err(err) = self.system_manager.lock().await.reboot() {
+                error!("Failed to reboot when became idle. {err}");
+            };
         }
     }
 
@@ -585,7 +587,7 @@ impl Machine for MachineMonitor {
             let system = self.system_manager.lock().await;
 
             warn!("Rebooting machine on request");
-            system.reboot();
+            system.reboot()?;
         }
         Ok(())
     }

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -73,6 +73,9 @@ pub trait SystemManager {
 
     /// Returns the list of active children, and none if the pid itself is not active
     fn get_proc_lineage(&self, pid: u32) -> Option<Vec<u32>>;
+
+    /// Request a system reboot
+    fn reboot(&self);
 }
 
 #[derive(Debug, Clone, Diagnostic, Error)]

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -75,7 +75,7 @@ pub trait SystemManager {
     fn get_proc_lineage(&self, pid: u32) -> Option<Vec<u32>>;
 
     /// Request a system reboot
-    fn reboot(&self);
+    fn reboot(&self) -> Result<()>;
 }
 
 #[derive(Debug, Clone, Diagnostic, Error)]

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -1052,8 +1052,6 @@ impl SystemManager for UnixSystem {
             .get(&pid)
             .map(|lineage| lineage.clone())
     }
-
-    // fn get_procs_by_pgid(&self, pgid: u32) -> Option<Vec<u32>> {}
 }
 
 #[cfg(test)]

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -1052,6 +1052,16 @@ impl SystemManager for UnixSystem {
             .get(&pid)
             .map(|lineage| lineage.clone())
     }
+
+    #[cfg(target_os = "linux")]
+    fn reboot(&self) {
+        nix::sys::reboot::reboot(nix::sys::reboot::RebootMode::RB_AUTOBOOT)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn reboot(&self) {
+        _ = Command::new("reboot").status();
+    }
 }
 
 #[cfg(test)]

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -1054,7 +1054,7 @@ impl SystemManager for UnixSystem {
     }
 
     #[cfg(target_os = "linux")]
-    fn reboot(&self) {
+    fn reboot(&self) -> Result<()> {
         nix::sys::reboot::reboot(nix::sys::reboot::RebootMode::RB_AUTOBOOT)
             .map(|_| ())
             .into_diagnostic()

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -12,7 +12,7 @@ use std::{
 use chrono::{DateTime, Local};
 use dashmap::DashMap;
 use itertools::Itertools;
-use miette::{IntoDiagnostic, Result, miette};
+use miette::{Context, IntoDiagnostic, Result, miette};
 use nix::sys::signal::{Signal, kill, killpg};
 use opencue_proto::{
     host::HardwareState,
@@ -1056,11 +1056,18 @@ impl SystemManager for UnixSystem {
     #[cfg(target_os = "linux")]
     fn reboot(&self) {
         nix::sys::reboot::reboot(nix::sys::reboot::RebootMode::RB_AUTOBOOT)
+            .map(|_| ())
+            .into_diagnostic()
+            .wrap_err("Failed to reboot")
     }
 
     #[cfg(target_os = "macos")]
-    fn reboot(&self) {
-        _ = Command::new("reboot").status();
+    fn reboot(&self) -> Result<()> {
+        Command::new("reboot")
+            .status()
+            .map(|_| ())
+            .into_diagnostic()
+            .wrap_err("Failed to reboot")
     }
 }
 


### PR DESCRIPTION
Implement CoreDetail methods for locking and unlocking cores and integrate them with RqdServant to handle lock/unlock API requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to lock and unlock a specified number of CPU cores, or all available cores, through new core management actions.
  - Added functionality to reboot the system immediately or defer reboot until idle, with new reboot controls accessible to users.
  - Enabled asynchronous status reporting and host report collection for improved system monitoring.
- **Bug Fixes**
  - Improved clarity in documentation for core reservation and release methods.
- **Chores**
  - Reduced logging verbosity for certain core reservation events.
  - Marked several RPC methods as deprecated to guide users away from outdated operations.
  - Simplified host report submission by consolidating multiple parameters into a single structured report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->