### PR TITLE
Minor fixes

### DIFF
--- a/crates/rqd/src/config/config.rs
+++ b/crates/rqd/src/config/config.rs
@@ -73,7 +73,6 @@ pub struct MachineConfig {
     pub proc_loadavg_path: String,
     pub temp_path: String,
     pub core_multiplier: u32,
-    pub use_session_id_for_proc_lineage: bool,
 }
 
 impl Default for MachineConfig {
@@ -85,14 +84,13 @@ impl Default for MachineConfig {
             custom_tags: vec![],
             nimby_mode: false,
             facility: "cloud".to_string(),
-            cpuinfo_path: "/etc/cpuinfo".to_string(),
+            cpuinfo_path: "/proc/cpuinfo".to_string(),
             distro_release_path: "/etc/*-release".to_string(),
             proc_stat_path: "/proc/stat".to_string(),
             inittab_path: "/etc/inittab".to_string(),
             proc_loadavg_path: "/proc/loadavg".to_string(),
             temp_path: "/tmp".to_string(),
             core_multiplier: 100,
-            use_session_id_for_proc_lineage: true,
         }
     }
 }

--- a/crates/rqd/src/frame/cache.rs
+++ b/crates/rqd/src/frame/cache.rs
@@ -39,8 +39,7 @@ impl RunningFrameCache {
                     .frame_stats
                     .read()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .clone()
-                    .unwrap_or_default();
+                    .clone();
                 RunningFrameInfo {
                     resource_id: running_frame.request.resource_id.clone(),
                     job_id: running_frame.request.job_id.to_string(),

--- a/crates/rqd/src/frame/frame_cmd.rs
+++ b/crates/rqd/src/frame/frame_cmd.rs
@@ -128,7 +128,7 @@ wait_for_output $exit_code
         use itertools::Itertools;
 
         let taskset_list = cpu_list.into_iter().map(|v| v.to_string()).join(",");
-        self.cmd.arg("taskset").arg("-p").arg(taskset_list.as_str());
+        self.cmd.arg("taskset").arg("-c").arg(taskset_list.as_str());
         self
     }
 

--- a/crates/rqd/src/servant/rqd_servant.rs
+++ b/crates/rqd/src/servant/rqd_servant.rs
@@ -76,7 +76,7 @@ impl RqdInterface for RqdServant {
             )))?;
 
         Ok(Response::new(RqdStaticGetRunningFrameStatusResponse {
-            running_frame_info: running_frame,
+            running_frame_info: Some(running_frame),
         }))
     }
 

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -206,6 +206,7 @@ impl MachineMonitor {
                 true
             }
         });
+        drop(system_monitor);
         self.handle_finished_frames(finished_frames).await;
         Ok(())
     }

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -191,11 +191,7 @@ impl MachineMonitor {
                     })
                 {
                     if let Ok(mut frame_stats) = running_frame.frame_stats.write() {
-                        if let Some(old_frame_stats) = frame_stats.as_mut() {
-                            old_frame_stats.update(proc_stats);
-                        } else {
-                            *frame_stats = Some(proc_stats);
-                        }
+                        frame_stats.update(proc_stats);
                     }
                     true
                 } else {
@@ -227,9 +223,8 @@ impl MachineMonitor {
         match host_state {
             Some(host_state) => {
                 for frame in finished_frames {
-                    if let (Some(finished_state), Some(frame_report)) =
-                        (frame.get_finished_state(), frame.into_running_frame_info())
-                    {
+                    if let Some(finished_state) = frame.get_finished_state() {
+                        let frame_report = frame.into_running_frame_info();
                         let exit_signal = match finished_state.exit_signal {
                             Some(signal) => signal as u32,
                             None => 0,

--- a/crates/rqd/src/system/machine.rs
+++ b/crates/rqd/src/system/machine.rs
@@ -236,11 +236,13 @@ impl MachineMonitor {
                         if let Some(procs) = &frame.cpu_list {
                             self.release_cpus(procs).await;
                         } else {
-                            self.release_cores(
-                                frame.request.num_cores as u32
-                                    / self.maching_config.core_multiplier,
-                            )
-                            .await;
+                            // Ensure the division rounds up if num_cores is not a multiple of
+                            // core_multiplier
+                            let num_cores_to_release = (frame.request.num_cores as u32
+                                + self.maching_config.core_multiplier
+                                - 1)
+                                / self.maching_config.core_multiplier;
+                            self.release_cores(num_cores_to_release).await;
                         }
 
                         // Send complete report

--- a/crates/rqd/src/system/manager.rs
+++ b/crates/rqd/src/system/manager.rs
@@ -219,7 +219,12 @@ impl ProcessStats {
             max_vsize: std::cmp::max(new.max_vsize, self.max_vsize),
             max_used_gpu_memory: std::cmp::max(new.max_used_gpu_memory, self.max_used_gpu_memory),
             run_time: std::cmp::max(new.run_time, self.run_time),
-            ..new
+            rss: new.rss,
+            vsize: new.vsize,
+            llu_time: new.llu_time,
+            used_gpu_memory: new.used_gpu_memory,
+            children: new.children,
+            epoch_start_time: new.epoch_start_time,
         };
     }
 }

--- a/crates/rqd/src/system/unix.rs
+++ b/crates/rqd/src/system/unix.rs
@@ -21,7 +21,7 @@ use opencue_proto::{
 use sysinfo::{
     DiskRefreshKind, Disks, MemoryRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System,
 };
-use tracing::{debug, warn};
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::config::config::MachineConfig;
@@ -43,9 +43,6 @@ pub struct UnixSystem {
     hardware_state: HardwareState,
     attributes: HashMap<String, String>,
     sysinfo_system: Mutex<sysinfo::System>,
-    // Cache of all processes and their children
-    // This cache is only active if use_session_id_for_proc_lineage=true
-    procs_children_cache: Option<DashMap<u32, Vec<u32>>>,
     // Cache of monitored processes and their lineage
     procs_lineage_cache: DashMap<u32, Vec<u32>>,
 }
@@ -142,10 +139,6 @@ impl UnixSystem {
                 available_cores: available_core_count,
             },
             sysinfo_system: Mutex::new(sysinfo::System::new()),
-            procs_children_cache: match config.use_session_id_for_proc_lineage {
-                true => None,
-                false => Some(DashMap::new()),
-            },
             procs_lineage_cache: DashMap::new(),
         })
     }
@@ -279,7 +272,11 @@ impl UnixSystem {
     /// A `Result` containing a `String` representing the hostname or IP address of the machine.
     fn get_hostname(use_ip_as_hostname: bool) -> Result<String> {
         let hostname = sysinfo::System::host_name()
-            .ok_or_else(|| miette::miette!("Failed to get hostname"))?;
+            .ok_or_else(|| miette::miette!("Failed to get hostname"))?
+            .split(".")
+            .next()
+            .ok_or(miette!("Invalid hostname format"))?
+            .to_string();
         if use_ip_as_hostname {
             let mut addrs_iter = format!("{}:443", hostname)
                 .to_socket_addrs()
@@ -548,45 +545,16 @@ impl UnixSystem {
             .sysinfo_system
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        if self.config.use_session_id_for_proc_lineage {
-            self.procs_lineage_cache.clear();
-            // Group all processes by session_id
-            for (session_pid, pid) in sysinfo.processes().iter().map(|(children_pid, proc)| {
-                let session_pid = proc.session_id().unwrap_or(Pid::from_u32(0)).as_u32();
-                (session_pid, children_pid.clone().as_u32())
-            }) {
-                self.procs_lineage_cache
-                    .entry(session_pid)
-                    .and_modify(|procs| procs.push(pid))
-                    .or_insert(vec![pid]);
-            }
-        } else {
-            let procs_children_cache = self.procs_children_cache.as_ref().expect(
-                "Invalid State. \
-                    procs_children_cache should be some if use_session_id_for_proc_lineage is true",
-            );
-            procs_children_cache.clear();
-
-            // Collect all procs and its direct children
-            for (parent_pid, pid) in sysinfo.processes().iter().map(|(children_pid, proc)| {
-                let parent_pid = proc.parent().unwrap_or(Pid::from_u32(0)).as_u32();
-                (parent_pid, children_pid.clone().as_u32())
-            }) {
-                procs_children_cache
-                    .entry(parent_pid)
-                    .and_modify(|children| children.push(pid))
-                    .or_insert(vec![pid]);
-            }
-            // Clear up procs that have finished (disapeared from procs_children_cache)
-            let procs_to_clear: Vec<u32> = self
-                .procs_lineage_cache
-                .iter()
-                .filter(|item| !procs_children_cache.contains_key(item.key()))
-                .map(|item| item.key().clone())
-                .collect();
-            for pid in procs_to_clear {
-                self.procs_lineage_cache.remove(&pid);
-            }
+        self.procs_lineage_cache.clear();
+        // Group all processes by session_id
+        for (session_pid, pid) in sysinfo.processes().iter().map(|(children_pid, proc)| {
+            let session_pid = proc.session_id().unwrap_or(Pid::from_u32(0)).as_u32();
+            (session_pid, children_pid.clone().as_u32())
+        }) {
+            self.procs_lineage_cache
+                .entry(session_pid)
+                .and_modify(|procs| procs.push(pid))
+                .or_insert(vec![pid]);
         }
     }
 
@@ -624,10 +592,12 @@ impl UnixSystem {
                                 )
                                 .format("%Y-%m-%d %H:%M:%S")
                                 .to_string();
+                                let proc_memory = proc.memory() / 1024 / 1024;
+                                let proc_vmemory = proc.virtual_memory() / 1024 / 1024;
                                 children.push(ProcStats {
                                     stat: Some(Stat {
-                                        rss: proc.memory() as i64,
-                                        vsize: proc.virtual_memory() as i64,
+                                        rss: proc_memory as i64,
+                                        vsize: proc_vmemory as i64,
                                         state: "".to_string(),
                                         name: proc.name().to_string_lossy().to_string(),
                                         pid: pid.to_string(),
@@ -638,7 +608,7 @@ impl UnixSystem {
                                     cmdline: format!("{:?}", proc.cmd()),
                                     start_time: start_time_str,
                                 });
-                                (proc.memory(), proc.virtual_memory(), 0, proc.run_time())
+                                (proc_memory, proc_vmemory, 0, proc.run_time())
                             }
                             None => (0, 0, 0, 0),
                         },
@@ -655,102 +625,6 @@ impl UnixSystem {
             children,
             sysinfo,
         )
-    }
-
-    /// Recursively calculates memory usage of a process and all of its child processes.
-    ///
-    /// # Arguments
-    ///
-    /// * `pid` - Process ID to calculate memory usage for
-    /// * `sysinfo` - Mutex guard containing system information
-    /// * `cycle_trace` - Vector of process IDs to detect recursive loops
-    ///
-    /// # Returns
-    ///
-    /// A tuple containing:
-    /// * Memory usage in bytes
-    /// * Virtual memory usage in bytes
-    /// * GPU memory usage in bytes
-    /// * The updated mutex guard reference
-    /// * The updated cycle_trace vector
-    ///
-    /// # Implementation Notes
-    ///
-    /// This function recursively traverses the process tree to sum up memory usage.
-    /// It uses cycle detection to prevent infinite loops in process hierarchies.
-    ///
-    /// GPU memory calculation is still pending
-    fn calculate_children_memory_traverse_lineage<'a>(
-        &'a self,
-        pid: &u32,
-        mut sysinfo: MutexGuard<'a, System>,
-        mut cycle_trace: Vec<u32>,
-    ) -> (u64, u64, u64, u64, MutexGuard<'a, System>, Vec<u32>) {
-        if let Some(procs_children_cache) = &self.procs_children_cache {
-            match sysinfo.process(Pid::from(pid.clone() as usize)) {
-                Some(proc) => match procs_children_cache.get(pid) {
-                    Some(children_pids) => {
-                        cycle_trace.push(pid.clone());
-                        let (
-                            mut sum_memory,
-                            mut sum_virtual_memory,
-                            mut sum_gpu_memory,
-                            mut run_time,
-                        ) = (proc.memory(), proc.virtual_memory(), 0, proc.run_time());
-                        for child_pid in children_pids.iter() {
-                            // Check for cycles to avoid an infinite loop
-                            if cycle_trace.contains(child_pid) {
-                                warn!(
-                                    "calculate_children_memory recursion found a loop.\
-                                Incomplete memory calculation for {pid}."
-                                );
-                                break;
-                            }
-                            let (
-                                child_memory,
-                                child_virtual_memory,
-                                child_gpu_memory,
-                                child_run_time,
-                                updated_sysinfo,
-                                updated_cycle_trace,
-                            ) = self.calculate_children_memory_traverse_lineage(
-                                child_pid,
-                                sysinfo,
-                                cycle_trace,
-                            );
-                            sum_memory += child_memory;
-                            sum_virtual_memory += child_virtual_memory;
-                            sum_gpu_memory += child_gpu_memory;
-                            run_time = std::cmp::max(run_time, child_run_time);
-                            // Update our reference to the mutex guard and cycle_trace
-                            sysinfo = updated_sysinfo;
-                            cycle_trace = updated_cycle_trace;
-                        }
-                        (
-                            sum_memory,
-                            sum_virtual_memory,
-                            sum_gpu_memory,
-                            run_time,
-                            sysinfo,
-                            cycle_trace,
-                        )
-                    }
-                    // Process has no children
-                    None => (
-                        proc.memory(),
-                        proc.virtual_memory(),
-                        0,
-                        proc.run_time(),
-                        sysinfo,
-                        Vec::new(),
-                    ),
-                },
-                // Process no longer exists
-                None => (0, 0, 0, 0, sysinfo, Vec::new()),
-            }
-        } else {
-            (0, 0, 0, 0, sysinfo, Vec::new())
-        }
     }
 }
 
@@ -930,74 +804,34 @@ impl SystemManager for UnixSystem {
             .sysinfo_system
             .lock()
             .unwrap_or_else(|err| err.into_inner());
-        if self.config.use_session_id_for_proc_lineage {
-            let (
-                summed_memory,
-                summed_virtual_memory,
-                summed_gpu_memory,
-                total_run_time,
-                children,
-                guard,
-            ) = self.calculate_session_memory(&pid, sysinfo);
+        let (
+            summed_memory,
+            summed_virtual_memory,
+            summed_gpu_memory,
+            total_run_time,
+            children,
+            guard,
+        ) = self.calculate_session_memory(&pid, sysinfo);
 
-            debug!(
-                "Collect frame stats fo {}. rss: {}mb virtual: {}mb gpu: {}mb",
-                pid,
-                summed_memory / 1024 / 1024,
-                summed_virtual_memory / 1024 / 1024,
-                summed_gpu_memory / 1024 / 1024
-            );
-            Ok(guard
-                .process(Pid::from(pid as usize))
-                .map(|proc| ProcessStats {
-                    // Caller is responsible for maintaining the Max value between calls
-                    max_rss: summed_memory,
-                    rss: summed_memory,
-                    max_vsize: summed_virtual_memory,
-                    vsize: summed_virtual_memory,
-                    llu_time: log_mtime,
-                    max_used_gpu_memory: 0,
-                    used_gpu_memory: summed_gpu_memory,
-                    children: Some(ChildrenProcStats { children }),
-                    epoch_start_time: proc.start_time(),
-                    run_time: total_run_time,
-                }))
-        } else {
-            // Traverse the tree of procs using their parent id and calculate memory consumption
-            let (
-                summed_memory,
-                summed_virtual_memory,
-                summed_gpu_memory,
-                total_run_time,
-                guard,
-                lineage,
-            ) = self.calculate_children_memory_traverse_lineage(&pid, sysinfo, Vec::new());
-
-            debug!(
-                "Collect frame stats fo {}. rss: {}mb virtual: {}mb gpu: {}mb",
-                pid,
-                summed_memory / 1024 / 1024,
-                summed_virtual_memory / 1024 / 1024,
-                summed_gpu_memory / 1024 / 1024
-            );
-
-            self.procs_lineage_cache.insert(pid, lineage);
-            Ok(guard
-                .process(Pid::from(pid as usize))
-                .map(|proc| ProcessStats {
-                    // Caller is responsible for maintaining the Max value between calls
-                    max_rss: summed_memory,
-                    rss: summed_memory,
-                    max_vsize: summed_virtual_memory,
-                    vsize: summed_virtual_memory,
-                    llu_time: log_mtime,
-                    max_used_gpu_memory: 0,
-                    used_gpu_memory: summed_gpu_memory,
-                    children: None,
-                    epoch_start_time: proc.start_time(),
-                    run_time: total_run_time,
-                }))
-        }
+        debug!(
+            "Collect frame stats fo {}. rss: {}kb virtual: {}kb gpu: {}kb",
+            pid, summed_memory, summed_virtual_memory, summed_gpu_memory
+        );
+        Ok(guard
+            .process(Pid::from(pid as usize))
+            .map(|proc| ProcessStats {
+                // Caller is responsible for maintaining the Max value between calls
+                max_rss: summed_memory,
+                rss: summed_memory,
+                max_vsize: summed_virtual_memory,
+                vsize: summed_virtual_memory,
+                llu_time: log_mtime,
+                max_used_gpu_memory: 0,
+                used_gpu_memory: summed_gpu_memory,
+                children: Some(ChildrenProcStats { children }),
+                epoch_start_time: proc.start_time(),
+                run_time: total_run_time,
+            }))
     }
 
     fn refresh_procs(&self) {
@@ -1426,7 +1260,6 @@ mod tests {
                 hardware_state: HardwareState::Up,
                 attributes: HashMap::new(),
                 sysinfo_system: Mutex::new(sysinfo::System::new()),
-                procs_children_cache: Some(DashMap::new()),
                 procs_lineage_cache: DashMap::new(),
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved memory calculation and reporting for processes by consistently using session ID grouping and reporting values in kilobytes.
	- Fixed hostname extraction to use only the first segment before optional IP resolution.

- **Refactor**
	- Simplified process lineage and memory aggregation logic by removing dual-mode behavior and code related to process children caching.
	- Streamlined resource release logic for finished frames, with improved logging and early exit for empty input.
	- Removed optional wrapping from frame statistics to simplify data handling and access.
	- Changed CPU affinity command usage to set affinity for new commands instead of existing processes.
	- Enhanced handling of running frame status responses to explicitly use optional values.

- **Chores**
	- Updated the default CPU info path to "/proc/cpuinfo".
	- Removed obsolete configuration and internal fields related to process lineage handling.
	- Made process statistics update logic more explicit with individual field assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->