### PR TITLE
Make frame recovery disabled everywhere but macos

### DIFF
--- a/crates/rqd/src/frame/manager.rs
+++ b/crates/rqd/src/frame/manager.rs
@@ -169,9 +169,11 @@ impl FrameManager {
                             .await
                             .map(|v| Some(v)),
                         None => {
+                            let num_cores = running_frame.request.num_cores as u32
+                                / self.config.machine.core_multiplier;
                             self.machine
                                 .reserve_cores(
-                                    running_frame.request.num_cores as usize,
+                                    num_cores as usize,
                                     running_frame.request.resource_id(),
                                     false,
                                 )
@@ -181,7 +183,7 @@ impl FrameManager {
                         errors.push(err.to_string());
                     }
                     if self.config.runner.run_on_docker {
-                        todo!()
+                        todo!("Recovering frames when running on docker is not yet supported")
                     } else {
                         self.spawn_running_frame(running_frame, true)
                     }

--- a/crates/rqd/src/main.rs
+++ b/crates/rqd/src/main.rs
@@ -74,6 +74,9 @@ async fn async_main(config: Config) -> miette::Result<()> {
     // Await for the confirmation machine_monitor has fully initialized
     let _machine_monitor_started = rx.await;
 
+    // Recovering frames is unstable on linux. Launched frames are somehow still bound
+    // to the rqd process and receive a kill signal when rqd stops
+    #[cfg(target_os = "macos")]
     if let Err(err) = frame_manager.recover_snapshots().await {
         warn!("Failed to recover frames from snapshot: {}", err);
     };

--- a/crates/rqd/src/main.rs
+++ b/crates/rqd/src/main.rs
@@ -5,7 +5,7 @@ use frame::manager::FrameManager;
 use miette::IntoDiagnostic;
 use report::report_client::ReportClient;
 use system::machine::MachineMonitor;
-use tokio::select;
+use tokio::{select, sync::oneshot};
 use tracing::{error, warn};
 use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
 
@@ -64,11 +64,15 @@ async fn async_main(config: Config) -> miette::Result<()> {
         machine: mm_clone.clone(),
     });
 
+    let (tx, rx) = oneshot::channel::<()>();
+
     // Spawn machine monitor on a new task to prevent it from locking the main task
     let machine_monitor_handle = {
         let mm = Arc::clone(&machine_monitor);
-        tokio::spawn(async move { mm.start().await })
+        tokio::spawn(async move { mm.start(tx).await })
     };
+    // Await for the confirmation machine_monitor has fully initialized
+    let _machine_monitor_started = rx.await;
 
     if let Err(err) = frame_manager.recover_snapshots().await {
         warn!("Failed to recover frames from snapshot: {}", err);


### PR DESCRIPTION
Recovering frames is unstable on linux. Launched frames are somehow still bound to the rqd process and receive a kill signal when rqd stops.$

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved CPU core reservation accuracy during frame recovery by properly accounting for machine configuration.
	- Enhanced error messaging for unsupported Docker recovery scenarios.

- **Refactor**
	- Simplified and streamlined snapshot file read/write operations for better performance and reduced complexity.
	- Improved startup synchronization for the machine monitor to ensure proper initialization before proceeding.
	- Clarified documentation regarding CPU core reservation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->